### PR TITLE
[codex] Prepare open source release and fix native navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ coverage/
 .vscode/
 
 # Local Codex/private log material
+.codex/
 fixtures/private/
 *.local.jsonl
 *.secret.jsonl

--- a/app-version.json
+++ b/app-version.json
@@ -1,5 +1,5 @@
 {
   "major": 0,
   "minor": 1,
-  "build": 91
+  "build": 96
 }

--- a/app-version.json
+++ b/app-version.json
@@ -1,5 +1,5 @@
 {
   "major": 0,
   "minor": 1,
-  "build": 96
+  "build": 98
 }

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -256,7 +256,7 @@ function printHelp(): void {
 Usage:
   codex-log-viewer projects [--path <file-or-dir>] [--json]
   codex-log-viewer summary [--project <name>] [--since YYYY-MM-DD] [--until YYYY-MM-DD] [--path <file-or-dir>] [--json]
-  codex-log-viewer sessions [--project <name>] [--since YYYY-MM-DD] [--until YYYY-MM-DD] [--json]
+  codex-log-viewer sessions [--project <name>] [--since YYYY-MM-DD] [--until YYYY-MM-DD] [--path <file-or-dir>] [--json]
   codex-log-viewer export [--format json|csv] [--output <file>] [summary options]
   codex-log-viewer export --format json --raw [summary options]
   codex-log-viewer audit [--repo <path>] [--project <name>] [--since YYYY-MM-DD] [--until YYYY-MM-DD] [--output <file>] [--raw] [--no-responses]

--- a/apps/macos/Sources/CodexLogViewerMac/AppModel.swift
+++ b/apps/macos/Sources/CodexLogViewerMac/AppModel.swift
@@ -80,6 +80,7 @@ final class AppModel: ObservableObject {
   private var searchRequestID = 0
   private var auditRequestID = 0
   private var pendingSearchResultTarget: SearchResultSelectionTarget?
+  private var pendingSearchConversationResult: MessageSearchResult?
   private let isEphemeralSettingsRun = ProcessInfo.processInfo.environment["CODEX_LOG_VIEWER_EPHEMERAL_SETTINGS"] == "1" ||
     ProcessInfo.processInfo.environment["CODEX_LOG_VIEWER_UI_TEST"] == "1"
   private var hasScheduledUITestQuit = false
@@ -314,10 +315,10 @@ final class AppModel: ObservableObject {
         if let selectedSessionID, !summary.sessions.contains(where: { $0.id == selectedSessionID }) {
           clearSelectedSession()
         }
-        if showSessionBrowser {
+        if showSessionBrowser && pendingSearchConversationResult == nil {
           selectLatestSessionIfNeeded(in: summary)
         }
-        loadBrowseMessages(selectFirstIfNeeded: !showSessionBrowser)
+        loadBrowseMessages(selectFirstIfNeeded: !showSessionBrowser && pendingSearchConversationResult == nil)
         status = .ready
         scheduleUITestWorkflowIfNeeded(api: api, filters: filters)
       } catch is CancellationError {
@@ -343,6 +344,7 @@ final class AppModel: ObservableObject {
   }
 
   func selectProject(_ project: String) {
+    guard selectedProject != project else { return }
     selectedProject = project
     updateAuditRepoPathSuggestion(force: true)
     clearAuditPreview()
@@ -403,32 +405,38 @@ final class AppModel: ObservableObject {
   }
 
   func setRepeatedPromptCategory(_ category: String, isVisible: Bool) {
+    var updatedCategories = hiddenRepeatedPromptCategories
     if isVisible {
-      hiddenRepeatedPromptCategories.remove(category)
+      updatedCategories.remove(category)
     } else {
-      hiddenRepeatedPromptCategories.insert(category)
+      updatedCategories.insert(category)
     }
+    hiddenRepeatedPromptCategories = updatedCategories
     saveSettings()
   }
 
   func setOperationalMessageCategory(_ category: String, isVisible: Bool) {
     guard isOperationalPromptCategory(category) else { return }
+    var updatedCategories = hiddenOperationalMessageCategories
     if isVisible {
-      hiddenOperationalMessageCategories.remove(category)
+      updatedCategories.remove(category)
     } else {
-      hiddenOperationalMessageCategories.insert(category)
+      updatedCategories.insert(category)
     }
+    hiddenOperationalMessageCategories = updatedCategories
     saveSettings()
     reconcileOperationalMessageFilters()
     refreshSearchForOperationalFilterChangeIfNeeded()
   }
 
   func setAllOperationalMessageCategoriesVisible(_ isVisible: Bool) {
+    var updatedCategories = hiddenOperationalMessageCategories
     if isVisible {
-      hiddenOperationalMessageCategories.subtract(Self.operationalPromptCategorySet)
+      updatedCategories.subtract(Self.operationalPromptCategorySet)
     } else {
-      hiddenOperationalMessageCategories.formUnion(Self.operationalPromptCategorySet)
+      updatedCategories.formUnion(Self.operationalPromptCategorySet)
     }
+    hiddenOperationalMessageCategories = updatedCategories
     saveSettings()
     reconcileOperationalMessageFilters()
     refreshSearchForOperationalFilterChangeIfNeeded()
@@ -590,6 +598,13 @@ final class AppModel: ObservableObject {
         if selectFirstIfNeeded, selectedBrowseMessageID == nil, let firstMessage = visibleResults.first {
           selectBrowseMessage(firstMessage.id)
         }
+        if let pendingSearchConversationResult {
+          self.pendingSearchConversationResult = nil
+          showConversation(for: pendingSearchConversationResult)
+        } else if selectedBrowseMessageID == nil,
+          let detail = selectedSessionDetail {
+          syncBrowseSelectionToSelectedUserMessage(in: detail)
+        }
       } catch is CancellationError {
         return
       } catch {
@@ -695,7 +710,27 @@ final class AppModel: ObservableObject {
     else {
       return
     }
+
+    let targetProject = projectScopeForSearchConversation(result)
+    if selectedProject != targetProject {
+      pendingSearchConversationResult = result
+      selectProject(targetProject)
+      return
+    }
+
+    showConversation(for: result)
+  }
+
+  private func projectScopeForSearchConversation(_ result: MessageSearchResult) -> String {
+    if selectedProject == AppConstants.allProjectsName {
+      return AppConstants.allProjectsName
+    }
+    return result.project.isEmpty ? selectedProject : result.project
+  }
+
+  private func showConversation(for result: MessageSearchResult) {
     selectedSection = .browse
+    selectedBrowseMessageID = browseMessageID(for: result)
     pendingSearchResultTarget = SearchResultSelectionTarget(result)
     selectedUserMessageIndex = nil
     selectedSessionID = sessionSelectionID(
@@ -1087,7 +1122,88 @@ final class AppModel: ObservableObject {
       return
     }
     selectedUserMessageIndex = userMessageIndex(for: pendingSearchResultTarget, in: detail)
+    syncBrowseSelectionToSelectedUserMessage(in: detail)
     self.pendingSearchResultTarget = nil
+  }
+
+  private func syncBrowseSelectionToSelectedUserMessage(in detail: SessionDetail) {
+    guard let selectedUserMessageIndex,
+      detail.messages.indices.contains(selectedUserMessageIndex)
+    else {
+      selectedBrowseMessageID = nil
+      return
+    }
+
+    selectedBrowseMessageID = browseMessageID(
+      for: detail.messages[selectedUserMessageIndex],
+      in: detail
+    )
+  }
+
+  private func browseMessageID(for result: MessageSearchResult) -> MessageSearchResult.ID? {
+    guard result.sourceEvent == "event_msg.user_message" else { return nil }
+    return visibleBrowseMessages(in: browseMessagesSummary?.results ?? [])
+      .first { browseResultRepresentsSameUserMessage($0, as: result) }?
+      .id
+  }
+
+  private func browseMessageID(
+    for message: MessageDetail,
+    in detail: SessionDetail
+  ) -> MessageSearchResult.ID? {
+    guard message.sourceEvent == "event_msg.user_message" else { return nil }
+    return visibleBrowseMessages(in: browseMessagesSummary?.results ?? [])
+      .first { result in
+        browseResultRepresentsUserMessage(result, message: message, detail: detail)
+      }?
+      .id
+  }
+
+  private func browseResultRepresentsSameUserMessage(
+    _ browseResult: MessageSearchResult,
+    as target: MessageSearchResult
+  ) -> Bool {
+    guard browseResult.sourceEvent == "event_msg.user_message",
+      browseResult.sessionId == target.sessionId,
+      browseResult.filePath == target.filePath,
+      browseResult.dateKey == target.dateKey,
+      browseResult.role == target.role,
+      browseResult.sourceEvent == target.sourceEvent
+    else {
+      return false
+    }
+
+    if let lineNumber = target.lineNumber {
+      return browseResult.lineNumber == lineNumber
+    }
+    if let turnId = target.turnId {
+      return browseResult.turnId == turnId && browseResult.content == target.content
+    }
+    return browseResult.timestamp == target.timestamp && browseResult.content == target.content
+  }
+
+  private func browseResultRepresentsUserMessage(
+    _ result: MessageSearchResult,
+    message: MessageDetail,
+    detail: SessionDetail
+  ) -> Bool {
+    guard result.sourceEvent == "event_msg.user_message",
+      result.sessionId == detail.file.sessionId,
+      result.filePath == detail.file.filePath,
+      result.dateKey == codexLocalDateKey(message.timestamp),
+      result.role == message.role,
+      result.sourceEvent == message.sourceEvent
+    else {
+      return false
+    }
+
+    if let lineNumber = message.lineNumber {
+      return result.lineNumber == lineNumber
+    }
+    if let turnId = message.turnId {
+      return result.turnId == turnId && result.content == message.content
+    }
+    return result.timestamp == message.timestamp && result.content == message.content
   }
 
   private func userMessageIndex(for target: SearchResultSelectionTarget, in detail: SessionDetail) -> Int? {
@@ -1234,14 +1350,23 @@ final class AppModel: ObservableObject {
       projectSortOption = sortOption
     }
     let savedHiddenOperationalCategories = Set(Self.stringArray(forKey: DefaultsKeys.hiddenOperationalMessageCategories))
+    let savedOperationalCategoryVersion = UserDefaults.standard.integer(
+      forKey: DefaultsKeys.operationalMessageCategoriesVersion
+    )
     if savedHiddenOperationalCategories.isEmpty,
       UserDefaults.standard.object(forKey: DefaultsKeys.showOperationalMessages) != nil,
       !UserDefaults.standard.bool(forKey: DefaultsKeys.showOperationalMessages) {
       hiddenOperationalMessageCategories = Self.operationalPromptCategorySet
     } else {
-      hiddenOperationalMessageCategories = savedHiddenOperationalCategories
+      hiddenOperationalMessageCategories = Self.migratedOperationalCategories(
+        savedHiddenOperationalCategories,
+        settingsVersion: savedOperationalCategoryVersion
+      )
     }
-    hiddenRepeatedPromptCategories = Set(Self.stringArray(forKey: DefaultsKeys.hiddenRepeatedPromptCategories))
+    hiddenRepeatedPromptCategories = Self.migratedRepeatedPromptCategories(
+      Set(Self.stringArray(forKey: DefaultsKeys.hiddenRepeatedPromptCategories)),
+      settingsVersion: savedOperationalCategoryVersion
+    )
     showSessionBrowser = UserDefaults.standard.bool(forKey: DefaultsKeys.showSessionBrowser)
   }
 
@@ -1259,6 +1384,7 @@ final class AppModel: ObservableObject {
     UserDefaults.standard.set(Self.dateFormatter.string(from: dateAnchorDate), forKey: DefaultsKeys.dateAnchorDate)
     UserDefaults.standard.set(projectSortOption.rawValue, forKey: DefaultsKeys.projectSortOption)
     UserDefaults.standard.set(Array(hiddenOperationalMessageCategories).sorted(), forKey: DefaultsKeys.hiddenOperationalMessageCategories)
+    UserDefaults.standard.set(Self.operationalMessageCategoriesVersion, forKey: DefaultsKeys.operationalMessageCategoriesVersion)
     UserDefaults.standard.removeObject(forKey: DefaultsKeys.showOperationalMessages)
     UserDefaults.standard.set(Array(hiddenRepeatedPromptCategories).sorted(), forKey: DefaultsKeys.hiddenRepeatedPromptCategories)
     UserDefaults.standard.set(showSessionBrowser, forKey: DefaultsKeys.showSessionBrowser)
@@ -1431,10 +1557,24 @@ final class AppModel: ObservableObject {
     )
     guard sentMessagesSearch.totalMatches == 1,
       sentMessagesSearch.results.first?.role == MessageRoleFilter.user.rawValue,
+      sentMessagesSearch.results.first?.category == "Testing/verification",
       sentMessagesSearch.results.first?.promptIntent == "Testing/verification",
       sentMessagesSearch.results.first?.snippet.contains("parser test") == true
     else {
       throw AppSmokeError.unexpected("The UI workflow sent-messages search did not return the fixture prompt.")
+    }
+    let hiddenOperationalSearch = try await api.searchMessages(
+      query: "",
+      role: .user,
+      model: AppConstants.allModelsName,
+      sessionID: nil,
+      project: selectedProject,
+      filters: dateFilters,
+      submittedOnly: true,
+      hiddenCategories: Self.operationalPromptCategoryOrder
+    )
+    guard hiddenOperationalSearch.totalMatches == 0 else {
+      throw AppSmokeError.unexpected("The UI workflow operational-message filter did not hide all fixture prompts.")
     }
 
     copySearchResultSessionID(result)
@@ -1488,6 +1628,15 @@ final class AppModel: ObservableObject {
       userMessageIndex(for: SearchResultSelectionTarget(assistantResult), in: detail) == firstUserMessage.offset
     else {
       throw AppSmokeError.unexpected("Assistant search results did not map back to their user-message interaction.")
+    }
+    browseMessagesSummary = sentMessagesSearch
+    pendingSearchResultTarget = SearchResultSelectionTarget(assistantResult)
+    selectedUserMessageIndex = nil
+    applyPendingMessageSelection(to: detail)
+    guard selectedUserMessageIndex == firstUserMessage.offset,
+      selectedBrowseMessageID == sentMessagesSearch.results.first?.id
+    else {
+      throw AppSmokeError.unexpected("Search result conversation navigation did not sync the highlighted user message.")
     }
     selectedSessionDetail = detail
 
@@ -1668,12 +1817,60 @@ final class AppModel: ObservableObject {
   }
 
   private static let operationalPromptCategoryOrder = [
+    "Code review/QA",
+    "Deploy/release",
+    "Git commands",
+    "Plan approvals",
+    "Run/build app",
+    "Testing/verification"
+  ]
+  private static let operationalPromptCategorySet = Set(operationalPromptCategoryOrder)
+  private static let legacyOperationalPromptCategorySet: Set<String> = [
     "Code review",
     "Git commands",
     "Plan approvals",
     "Run app"
   ]
-  private static let operationalPromptCategorySet = Set(operationalPromptCategoryOrder)
+  private static let operationalMessageCategoriesVersion = 2
+
+  private static func migratedOperationalCategories(
+    _ categories: Set<String>,
+    settingsVersion: Int
+  ) -> Set<String> {
+    migratedCategoryLabels(categories, settingsVersion: settingsVersion)
+      .intersection(operationalPromptCategorySet)
+  }
+
+  private static func migratedRepeatedPromptCategories(
+    _ categories: Set<String>,
+    settingsVersion: Int
+  ) -> Set<String> {
+    migratedCategoryLabels(categories, settingsVersion: settingsVersion)
+  }
+
+  private static func migratedCategoryLabels(
+    _ categories: Set<String>,
+    settingsVersion: Int
+  ) -> Set<String> {
+    guard settingsVersion < operationalMessageCategoriesVersion else {
+      return categories
+    }
+
+    var migrated = categories
+    if migrated.remove("Code review") != nil {
+      migrated.insert("Code review/QA")
+    }
+    if migrated.remove("Run app") != nil {
+      migrated.insert("Run/build app")
+    }
+    if categories.contains("Git commands") {
+      migrated.insert("Deploy/release")
+    }
+    if legacyOperationalPromptCategorySet.isSubset(of: categories) {
+      migrated.formUnion(operationalPromptCategorySet)
+    }
+    return migrated
+  }
 
   private static func writeStdout(_ message: String) {
     FileHandle.standardOutput.write(Data(message.utf8))
@@ -1711,7 +1908,7 @@ final class AppModel: ObservableObject {
     Project Focus shows the main types of work in the current project and date range.
 
     Filters
-    Use the date control in the header. Use View > Operational Messages to hide Git, plan approval, run app, and code review prompts. Use View > Show Sessions only when you need the session column.
+    Use the date control in the header. In View > Operational Messages, All shows every message in the current scope; unchecking it hides approvals, Git, release, run/build, testing, and review prompts. Use View > Show Sessions only when you need the session column.
 
     Search and Audit
     Search finds messages across the current filters. Audit prepares a reviewed AI worklog for the selected repository.
@@ -1790,6 +1987,7 @@ private enum DefaultsKeys {
   static let projectSortOption = "projectSortOption"
   static let showOperationalMessages = "showOperationalMessages"
   static let hiddenOperationalMessageCategories = "hiddenOperationalMessageCategories"
+  static let operationalMessageCategoriesVersion = "operationalMessageCategoriesVersion"
   static let hiddenRepeatedPromptCategories = "hiddenRepeatedPromptCategories"
   static let showSessionBrowser = "showSessionBrowser"
 }

--- a/apps/macos/Sources/CodexLogViewerMac/AppModel.swift
+++ b/apps/macos/Sources/CodexLogViewerMac/AppModel.swift
@@ -66,6 +66,7 @@ final class AppModel: ObservableObject {
   @Published var auditStatusMessage: String?
   @Published var isAuditLoading = false
 
+  private var exportDirectoryPath = ""
   private var api: LogEngineAPI?
   private var hasStarted = false
   private var refreshToken = 0
@@ -91,6 +92,21 @@ final class AppModel: ObservableObject {
 
   var browseMessages: [MessageSearchResult] {
     visibleBrowseMessages(in: browseMessagesSummary?.results ?? [])
+  }
+
+  var areBrowseMessagesHiddenByOperationalFilters: Bool {
+    guard let summary = browseMessagesSummary,
+      summary.totalMatches > 0,
+      !hiddenOperationalMessageCategories.isEmpty,
+      visibleBrowseMessages(in: summary.results).isEmpty
+    else {
+      return false
+    }
+
+    return summary.results.contains { result in
+      guard let category = result.category else { return false }
+      return hiddenOperationalMessageCategories.contains(category)
+    }
   }
 
   var searchResults: [MessageSearchResult] {
@@ -779,6 +795,7 @@ final class AppModel: ObservableObject {
     let panel = NSSavePanel()
     panel.canCreateDirectories = true
     panel.nameFieldStringValue = exportFilename(format)
+    panel.directoryURL = defaultExportDirectoryURL()
     if format == .json, !confirmJsonExport() {
       return
     }
@@ -791,6 +808,7 @@ final class AppModel: ObservableObject {
         status = .loading
         let data = try await api.exportSummary(format: format, project: project, filters: filters)
         try data.write(to: destinationURL)
+        rememberExportDirectory(destinationURL.deletingLastPathComponent())
         status = .ready
       } catch {
         status = .failed(error.localizedDescription)
@@ -808,11 +826,16 @@ final class AppModel: ObservableObject {
     panel.canCreateDirectories = false
 
     guard panel.runModal() == .OK, let url = panel.url else { return }
-    auditRepoPathDraft = url.path
-    clearAuditPreview()
+    setAuditRepoPathDraft(url.path)
   }
 
   func auditRepoPathChanged() {
+    clearAuditPreview()
+  }
+
+  func setAuditRepoPathDraft(_ path: String) {
+    guard auditRepoPathDraft != path else { return }
+    auditRepoPathDraft = path
     clearAuditPreview()
   }
 
@@ -1290,6 +1313,9 @@ final class AppModel: ObservableObject {
     selectedProject = AppConstants.allProjectsName
     clearSelectionState()
     refresh(force: true)
+    DispatchQueue.main.async {
+      Self.restoreViewerWindow(activate: true)
+    }
   }
 
   private func uniqueNonEmptyPaths(_ paths: [String]) -> [String] {
@@ -1324,6 +1350,7 @@ final class AppModel: ObservableObject {
     sourcePaths = Self.stringArray(forKey: DefaultsKeys.sourcePaths)
     recentSourcePaths = Self.stringArray(forKey: DefaultsKeys.recentSourcePaths)
     pathDraft = sourcePaths.joined(separator: "\n")
+    exportDirectoryPath = UserDefaults.standard.string(forKey: DefaultsKeys.exportDirectoryPath) ?? ""
     hasSinceFilter = UserDefaults.standard.bool(forKey: DefaultsKeys.hasSinceFilter)
     hasUntilFilter = UserDefaults.standard.bool(forKey: DefaultsKeys.hasUntilFilter)
     if let savedSinceDate = Self.date(forKey: DefaultsKeys.sinceDate) {
@@ -1376,6 +1403,7 @@ final class AppModel: ObservableObject {
     }
     UserDefaults.standard.set(sourcePaths, forKey: DefaultsKeys.sourcePaths)
     UserDefaults.standard.set(recentSourcePaths, forKey: DefaultsKeys.recentSourcePaths)
+    UserDefaults.standard.set(exportDirectoryPath, forKey: DefaultsKeys.exportDirectoryPath)
     UserDefaults.standard.set(hasSinceFilter, forKey: DefaultsKeys.hasSinceFilter)
     UserDefaults.standard.set(hasUntilFilter, forKey: DefaultsKeys.hasUntilFilter)
     UserDefaults.standard.set(Self.dateFormatter.string(from: sinceDate), forKey: DefaultsKeys.sinceDate)
@@ -1576,6 +1604,13 @@ final class AppModel: ObservableObject {
     guard hiddenOperationalSearch.totalMatches == 0 else {
       throw AppSmokeError.unexpected("The UI workflow operational-message filter did not hide all fixture prompts.")
     }
+    browseMessagesSummary = sentMessagesSearch
+    let previousHiddenOperationalCategories = hiddenOperationalMessageCategories
+    hiddenOperationalMessageCategories = ["Testing/verification"]
+    guard areBrowseMessagesHiddenByOperationalFilters, browseMessages.isEmpty else {
+      throw AppSmokeError.unexpected("The project browse empty state did not detect operationally hidden messages.")
+    }
+    hiddenOperationalMessageCategories = previousHiddenOperationalCategories
 
     copySearchResultSessionID(result)
     guard Self.pasteboardText() == result.sessionId else {
@@ -1677,6 +1712,24 @@ final class AppModel: ObservableObject {
     else {
       throw AppSmokeError.unexpected("The UI workflow export checks did not pass.")
     }
+
+    let previousExportDirectoryPath = exportDirectoryPath
+    if let fixturePath = filters.paths.first {
+      let fixtureDirectory = URL(fileURLWithPath: fixturePath).deletingLastPathComponent()
+      exportDirectoryPath = fixtureDirectory.path
+      guard defaultExportDirectoryURL().standardizedFileURL.path != fixtureDirectory.standardizedFileURL.path else {
+        throw AppSmokeError.unexpected("The export destination fallback still points at the selected log source.")
+      }
+    }
+    exportDirectoryPath = previousExportDirectoryPath
+
+    let previousAuditRepoPath = auditRepoPathDraft
+    setAuditRepoPathDraft(FileManager.default.temporaryDirectory.appendingPathComponent("codex-log-viewer-audit-smoke").path)
+    guard canGenerateAudit else {
+      throw AppSmokeError.unexpected("Manual Audit repository path entry did not enable preview generation.")
+    }
+    auditRepoPathDraft = previousAuditRepoPath
+    clearAuditPreview()
   }
 
   private func currentFilters(refreshToken: Int = 0, rebuildCache: Bool = false) -> LogFilters {
@@ -1687,6 +1740,59 @@ final class AppModel: ObservableObject {
       refreshToken: refreshToken,
       rebuildCache: rebuildCache
     )
+  }
+
+  private func defaultExportDirectoryURL() -> URL {
+    let savedURL = URL(fileURLWithPath: exportDirectoryPath, isDirectory: true)
+    if !exportDirectoryPath.isEmpty,
+      directoryExists(savedURL),
+      isSafeExportDirectory(savedURL) {
+      return savedURL
+    }
+
+    if let downloadsURL = FileManager.default.urls(for: .downloadsDirectory, in: .userDomainMask).first,
+      directoryExists(downloadsURL),
+      isSafeExportDirectory(downloadsURL) {
+      return downloadsURL
+    }
+
+    return FileManager.default.homeDirectoryForCurrentUser
+  }
+
+  private func rememberExportDirectory(_ url: URL) {
+    let directoryURL = url.standardizedFileURL
+    exportDirectoryPath = directoryURL.path
+    guard !isEphemeralSettingsRun else { return }
+    UserDefaults.standard.set(exportDirectoryPath, forKey: DefaultsKeys.exportDirectoryPath)
+  }
+
+  private func directoryExists(_ url: URL) -> Bool {
+    var isDirectory: ObjCBool = false
+    return FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory) && isDirectory.boolValue
+  }
+
+  private func isSafeExportDirectory(_ url: URL) -> Bool {
+    let exportPath = Self.normalizedDirectoryPath(url.path)
+    guard !exportPath.isEmpty else { return false }
+    return !sourcePaths.contains { sourcePath in
+      let sourceURL = URL(fileURLWithPath: sourcePath)
+      let sourceDirectoryPath: String
+      if directoryExists(sourceURL) {
+        sourceDirectoryPath = Self.normalizedDirectoryPath(sourceURL.path)
+      } else {
+        sourceDirectoryPath = Self.normalizedDirectoryPath(sourceURL.deletingLastPathComponent().path)
+      }
+      guard !sourceDirectoryPath.isEmpty else { return false }
+      return exportPath == sourceDirectoryPath || exportPath.hasPrefix("\(sourceDirectoryPath)/")
+    }
+  }
+
+  private static func normalizedDirectoryPath(_ path: String) -> String {
+    let normalized = URL(fileURLWithPath: path, isDirectory: true).standardizedFileURL.path
+    guard normalized.count > 1, normalized.hasSuffix("/") else {
+      return normalized
+    }
+    return String(normalized.dropLast())
   }
 
   private func exportFilename(_ format: ExportFormat) -> String {
@@ -1921,6 +2027,8 @@ final class AppModel: ObservableObject {
     alert.addButton(withTitle: "Open Usage Guide")
     if alert.runModal() == .alertSecondButtonReturn {
       Self.openUsageGuide()
+    } else {
+      Self.restoreViewerWindow(activate: true)
     }
   }
 
@@ -1930,6 +2038,20 @@ final class AppModel: ObservableObject {
 
     if let usageGuideURL {
       NSWorkspace.shared.open(usageGuideURL)
+    }
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+      Self.restoreViewerWindow(activate: false)
+    }
+  }
+
+  static func restoreViewerWindow(activate: Bool) {
+    if let appDelegate = NSApp.delegate as? AppDelegate {
+      appDelegate.ensureViewerWindowVisible(activate: activate)
+    } else if let window = NSApp.windows.first {
+      window.makeKeyAndOrderFront(nil)
+      if activate {
+        NSApp.activate(ignoringOtherApps: true)
+      }
     }
   }
 
@@ -1978,6 +2100,7 @@ private struct SearchResultSelectionTarget {
 private enum DefaultsKeys {
   static let sourcePaths = "sourcePaths"
   static let recentSourcePaths = "recentSourcePaths"
+  static let exportDirectoryPath = "exportDirectoryPath"
   static let hasSinceFilter = "hasSinceFilter"
   static let hasUntilFilter = "hasUntilFilter"
   static let sinceDate = "sinceDate"

--- a/apps/macos/Sources/CodexLogViewerMac/AppVersion.swift
+++ b/apps/macos/Sources/CodexLogViewerMac/AppVersion.swift
@@ -4,8 +4,8 @@
 enum AppVersion {
   static let major = 0
   static let minor = 1
-  static let build = 96
+  static let build = 98
   static let marketingVersion = "0.1"
-  static let bundleVersion = "96"
-  static let displayVersion = "0.1 (Build 96)"
+  static let bundleVersion = "98"
+  static let displayVersion = "0.1 (Build 98)"
 }

--- a/apps/macos/Sources/CodexLogViewerMac/AppVersion.swift
+++ b/apps/macos/Sources/CodexLogViewerMac/AppVersion.swift
@@ -4,8 +4,8 @@
 enum AppVersion {
   static let major = 0
   static let minor = 1
-  static let build = 91
+  static let build = 96
   static let marketingVersion = "0.1"
-  static let bundleVersion = "91"
-  static let displayVersion = "0.1 (Build 91)"
+  static let bundleVersion = "96"
+  static let displayVersion = "0.1 (Build 96)"
 }

--- a/apps/macos/Sources/CodexLogViewerMac/CodexLogViewerApp.swift
+++ b/apps/macos/Sources/CodexLogViewerMac/CodexLogViewerApp.swift
@@ -177,6 +177,7 @@ private struct AppWindowRootView: View {
   var body: some View {
     RootView()
       .environmentObject(model)
+      .focusedSceneValue(\.appModel, model)
       .focusedValue(\.appModel, model)
       .task {
         model.startIfNeeded()

--- a/apps/macos/Sources/CodexLogViewerMac/CodexLogViewerApp.swift
+++ b/apps/macos/Sources/CodexLogViewerMac/CodexLogViewerApp.swift
@@ -14,6 +14,11 @@ struct CodexLogViewerApp: App {
         EmptyView()
       } else {
         AppWindowRootView()
+          .onAppear {
+            appDelegate.setMainWindowOpener {
+              openWindow(id: AppWindowID.main)
+            }
+          }
       }
     }
     .commands {
@@ -199,6 +204,26 @@ private extension FocusedValues {
 
 final class AppDelegate: NSObject, NSApplicationDelegate {
   private var tabBarObservers: [NSObjectProtocol] = []
+  private var openMainWindow: (() -> Void)?
+  private var fallbackViewerWindow: NSWindow?
+
+  func setMainWindowOpener(_ opener: @escaping () -> Void) {
+    openMainWindow = opener
+  }
+
+  func ensureViewerWindowVisible(activate: Bool) {
+    if let window = preferredViewerWindow() {
+      window.makeKeyAndOrderFront(nil)
+      if activate {
+        NSApp.activate(ignoringOtherApps: true)
+      }
+      syncViewerTabBars()
+      return
+    }
+
+    openMainWindow?()
+    restoreViewerWindowAfterOpening(activate: activate, attemptsRemaining: 8)
+  }
 
   func openViewerTab(openWindow: @escaping () -> Void) {
     let sourceWindow = preferredViewerWindow()
@@ -238,6 +263,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
   func applicationWillTerminate(_ notification: Notification) {
     removeTabBarVisibilityObservers()
     LocalLogEngineServer.shared.stop()
+  }
+
+  func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+    if !flag {
+      ensureViewerWindowVisible(activate: true)
+    }
+    return true
   }
 
   private func installTabBarVisibilityObservers() {
@@ -348,6 +380,50 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
       }
       return window
     }.first ?? NSApp.windows.first(where: isViewerWindow)
+  }
+
+  private func restoreViewerWindowAfterOpening(activate: Bool, attemptsRemaining: Int) {
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+      guard let self else { return }
+      if let window = self.preferredViewerWindow() {
+        window.makeKeyAndOrderFront(nil)
+        if activate {
+          NSApp.activate(ignoringOtherApps: true)
+        }
+        self.syncViewerTabBars()
+        return
+      }
+
+      guard attemptsRemaining > 0 else {
+        self.openFallbackViewerWindow(activate: activate)
+        self.syncViewerTabBars()
+        return
+      }
+
+      self.restoreViewerWindowAfterOpening(
+        activate: activate,
+        attemptsRemaining: attemptsRemaining - 1
+      )
+    }
+  }
+
+  private func openFallbackViewerWindow(activate: Bool) {
+    let window = fallbackViewerWindow ?? NSWindow(
+      contentRect: NSRect(x: 0, y: 0, width: 1040, height: 680),
+      styleMask: [.titled, .closable, .miniaturizable, .resizable],
+      backing: .buffered,
+      defer: false
+    )
+    fallbackViewerWindow = window
+    window.title = "Codex Logs"
+    window.minSize = NSSize(width: 760, height: 560)
+    window.tabbingMode = .preferred
+    window.contentView = NSHostingView(rootView: AppWindowRootView())
+    window.center()
+    window.makeKeyAndOrderFront(nil)
+    if activate {
+      NSApp.activate(ignoringOtherApps: true)
+    }
   }
 
   private func isViewerWindow(_ window: NSWindow) -> Bool {

--- a/apps/macos/Sources/CodexLogViewerMac/RootView.swift
+++ b/apps/macos/Sources/CodexLogViewerMac/RootView.swift
@@ -641,9 +641,13 @@ struct SentMessagesBrowserColumn: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     } else if browseMessages.isEmpty {
       ContentUnavailableView(
-        "No Sent Messages",
+        model.areBrowseMessagesHiddenByOperationalFilters ? "No Visible Messages" : "No Sent Messages",
         systemImage: "paperplane",
-        description: Text("No submitted messages match the selected project and date filters.")
+        description: Text(
+          model.areBrowseMessagesHiddenByOperationalFilters
+            ? "Turn on at least one operational message family in the View menu."
+            : "No submitted messages match the selected project and date filters."
+        )
       )
       .frame(maxWidth: .infinity, maxHeight: .infinity)
     } else {
@@ -989,12 +993,15 @@ struct AuditControlBar: View {
       HStack(spacing: 10) {
         Image(systemName: "folder")
           .foregroundStyle(.secondary)
-        TextField("Repository path", text: $model.auditRepoPathDraft)
+        TextField(
+          "Repository path",
+          text: Binding(
+            get: { model.auditRepoPathDraft },
+            set: { model.setAuditRepoPathDraft($0) }
+          )
+        )
           .textFieldStyle(.roundedBorder)
           .accessibilityIdentifier("audit-repo-path-field")
-          .onChange(of: model.auditRepoPathDraft) { _, _ in
-            model.auditRepoPathChanged()
-          }
         Button {
           model.chooseAuditRepoPath()
         } label: {

--- a/apps/macos/Sources/CodexLogViewerMac/RootView.swift
+++ b/apps/macos/Sources/CodexLogViewerMac/RootView.swift
@@ -231,7 +231,12 @@ struct SidebarView: View {
   @EnvironmentObject private var model: AppModel
 
   var body: some View {
-    List(selection: $model.selectedProject) {
+    List(
+      selection: Binding(
+        get: { model.selectedProject },
+        set: { model.selectProject($0) }
+      )
+    ) {
       Section("Library") {
         ProjectListRow(
           title: AppConstants.allProjectsName,
@@ -263,9 +268,6 @@ struct SidebarView: View {
     .listStyle(.sidebar)
     .navigationTitle("Codex Logs")
     .accessibilityIdentifier("project-sidebar")
-    .onChange(of: model.selectedProject) { _, newValue in
-      model.selectProject(newValue)
-    }
   }
 
   private func countLabel(_ count: Int, singular: String, plural: String) -> String {
@@ -597,22 +599,33 @@ struct SentMessagesBrowserColumn: View {
       )
       .frame(maxWidth: .infinity, maxHeight: .infinity)
     } else {
-      List(sessionUserMessages, id: \.offset) { item in
-        Button {
-          model.selectedUserMessageIndex = item.offset
-        } label: {
-          SentMessageBrowserRow(
-            message: item.element,
-            isSelected: model.selectedUserMessageIndex == item.offset
-          )
+      ScrollViewReader { proxy in
+        List(sessionUserMessages, id: \.offset) { item in
+          Button {
+            model.selectedUserMessageIndex = item.offset
+          } label: {
+            SentMessageBrowserRow(
+              message: item.element,
+              isSelected: model.selectedUserMessageIndex == item.offset
+            )
+          }
+          .id(item.offset)
+          .frame(maxWidth: .infinity, alignment: .leading)
+          .contentShape(Rectangle())
+          .buttonStyle(.plain)
+          .listRowInsets(EdgeInsets(top: 4, leading: 8, bottom: 4, trailing: 8))
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .contentShape(Rectangle())
-        .buttonStyle(.plain)
-        .listRowInsets(EdgeInsets(top: 4, leading: 8, bottom: 4, trailing: 8))
+        .listStyle(.plain)
+        .accessibilityIdentifier("browse-messages-list")
+        .onChange(of: model.selectedUserMessageIndex) { _, newValue in
+          guard let newValue else { return }
+          proxy.scrollTo(newValue, anchor: .center)
+        }
+        .onAppear {
+          guard let selectedUserMessageIndex = model.selectedUserMessageIndex else { return }
+          proxy.scrollTo(selectedUserMessageIndex, anchor: .center)
+        }
       }
-      .listStyle(.plain)
-      .accessibilityIdentifier("browse-messages-list")
     }
   }
 
@@ -634,22 +647,33 @@ struct SentMessagesBrowserColumn: View {
       )
       .frame(maxWidth: .infinity, maxHeight: .infinity)
     } else {
-      List(browseMessages) { message in
-        Button {
-          model.selectBrowseMessage(message.id)
-        } label: {
-          SentMessageResultBrowserRow(
-            message: message,
-            isSelected: model.selectedBrowseMessageID == message.id
-          )
+      ScrollViewReader { proxy in
+        List(browseMessages) { message in
+          Button {
+            model.selectBrowseMessage(message.id)
+          } label: {
+            SentMessageResultBrowserRow(
+              message: message,
+              isSelected: model.selectedBrowseMessageID == message.id
+            )
+          }
+          .id(message.id)
+          .frame(maxWidth: .infinity, alignment: .leading)
+          .contentShape(Rectangle())
+          .buttonStyle(.plain)
+          .listRowInsets(EdgeInsets(top: 4, leading: 8, bottom: 4, trailing: 8))
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .contentShape(Rectangle())
-        .buttonStyle(.plain)
-        .listRowInsets(EdgeInsets(top: 4, leading: 8, bottom: 4, trailing: 8))
+        .listStyle(.plain)
+        .accessibilityIdentifier("browse-messages-list")
+        .onChange(of: model.selectedBrowseMessageID) { _, newValue in
+          guard let newValue else { return }
+          proxy.scrollTo(newValue, anchor: .center)
+        }
+        .onAppear {
+          guard let selectedBrowseMessageID = model.selectedBrowseMessageID else { return }
+          proxy.scrollTo(selectedBrowseMessageID, anchor: .center)
+        }
       }
-      .listStyle(.plain)
-      .accessibilityIdentifier("browse-messages-list")
     }
   }
 
@@ -2489,16 +2513,19 @@ struct SessionUserMessagesInspector: View {
   }
 
   private var userMessages: [(offset: Int, element: MessageDetail)] {
-    model.visibleUserMessageOffsets(in: detail)
+    model.visibleUserMessageOffsets(in: detail, dateKey: model.selectedSessionDateKey)
   }
 
   private var allUserMessages: [(offset: Int, element: MessageDetail)] {
-    SessionInteractionBuilder.userMessageOffsets(in: detail)
+    SessionInteractionBuilder.userMessageOffsets(in: detail, dateKey: model.selectedSessionDateKey)
   }
 
   private var automationMessages: [(offset: Int, element: MessageDetail)] {
     Array(detail.messages.enumerated())
-      .filter { $0.element.sourceEvent == "event_msg.automation_message" }
+      .filter {
+        $0.element.sourceEvent == "event_msg.automation_message" &&
+          (model.selectedSessionDateKey == nil || codexLocalDateKey($0.element.timestamp) == model.selectedSessionDateKey)
+      }
   }
 
   private var selectedInteraction: SessionInteraction? {

--- a/docs/ai-worklog.md
+++ b/docs/ai-worklog.md
@@ -2,6 +2,163 @@
 
 Sanitized audit trail of AI-assisted work on this project.
 
+## 2026-05-20 - Execute Manual QA Fix Plan
+
+Status: Completed
+Related commit/PR: TBD
+
+### User Messages
+
+> /goal execute the Manual QA Fixed Plan make sure that it's properly tested and everything is working to a full regression pass and verify that the app is working as intended
+
+> do we have much more to go?
+
+> i think we are done
+
+### Interpreted Intent
+
+The user wanted the documented manual QA issues fixed, regression-tested, packaged, and verified in the native macOS app, then stopped once they indicated the pass was complete enough.
+
+### Response / Work Done
+
+- Implemented native smoke cleanup so the packaged app and child parser engine are quit and leak-checked after UI smoke runs.
+- Restored the viewer window after source picker, Help, usage-guide, and app-reopen lifecycle paths.
+- Added a fallback AppKit viewer window path when SwiftUI window reopening cannot recover a visible viewer.
+- Clarified Browse empty-state copy when operational filters hide every visible submitted message.
+- Changed export save panels to default to a safe directory such as Downloads instead of the selected log source.
+- Fixed Audit repository path typing so manual entry clears stale preview state and enables Generate.
+- Expanded the native UI smoke workflow to cover operational hidden-message behavior, safe export defaults, Audit path entry, and process cleanup.
+- Rebuilt and repackaged the macOS app for desktop review.
+
+### Privacy Notes
+
+No raw Codex logs, unsanitized session files, private prompts, screenshots, recordings, export payloads, or secrets were added. Manual verification used the sanitized fixture session and temporary local QA directories.
+
+### Verification
+
+- Ran `wt bootstrap`.
+- Ran `node --check scripts/smoke-native-ui.mjs`.
+- Ran `git diff --check`.
+- Ran `npm run check:mac-accessibility`.
+- Ran `swift build --package-path apps/macos`.
+- Ran `npm test`.
+- Ran `npm run lint`.
+- Ran `npm run privacy:scan`.
+- Ran `npm run check:reference -- --reference fixtures/codex/sample-reference-summary.json --path fixtures/codex/sample-session.jsonl --project sample-app`.
+- Ran `npm run package:mac`.
+- Ran `npm run smoke:mac-package`.
+- Ran `npm run smoke:mac-ui` before the final Usage Guide fallback patch; did not start another UI smoke after the user indicated the pass was done.
+- Manually verified source picker restoration, Browse, Overview, Search role/model/date filters, operational filter empty state, JSON/CSV export save destinations, Audit manual path entry, and Help dialog behavior in the packaged app.
+
+## 2026-05-20 - Manual QA Issue Fix Plan
+
+Status: Completed
+Related commit/PR: TBD
+
+### User Messages
+
+> All right create a plan to fix all the issues
+
+### Interpreted Intent
+
+The user wanted the manual QA findings converted into an actionable implementation plan that can be used to fix every documented issue in a later coding pass.
+
+### Response / Work Done
+
+- Reviewed the manual QA report and the relevant native app and smoke-test code paths.
+- Created `docs/manual-qa-fix-plan-2026-05-20.md` with ordered phases, likely files to touch, implementation steps, acceptance criteria, and final verification.
+- Sequenced the plan to address process/window lifecycle defects first, then Browse empty-state copy, export destination safety, Audit manual path entry, and expanded regression coverage.
+
+### Privacy Notes
+
+No raw Codex logs, private sessions, screenshots, recordings, export payloads, or secrets were added. The plan references sanitized fixture workflows and code paths only.
+
+### Verification
+
+- Documentation-only change; no app rebuild or relaunch was needed.
+
+## 2026-05-20 - Manual macOS Power-User QA Pass
+
+Status: Completed
+Related commit/PR: TBD
+
+### User Messages
+
+> I want you to create a detailed plan to test our application. I want you to open the app on my desktop and I want you to use every feature of it and make sure that it's working as intended. Click on every menu item. Click on every aspect of the UI. Do all the filters. Act as a power user would. Test everything that's in there and make sure you document any issues that come up.
+>
+> If there are any issues found, create an implementation plan or create an issues ticket document with all the issues found so that later we can create an implementation plan to address every single one of them. Do you understand what I'm asking for? I want you to drive my application on my desktop. I want you to use every feature and capability of it and I want you to verify that it's working as intended, including every menu item and all the capabilities available. Then I want you to document any and every issue found and then we're going to create a plan to fix them.
+
+### Interpreted Intent
+
+The user wanted a hands-on native macOS QA pass that treated the app like a power-user would, exercised the menu and UI surface, verified filters and workflows, and produced a ticket-style issue document plus a follow-up implementation plan.
+
+### Response / Work Done
+
+- Bootstrapped the worktree before verification.
+- Launched and drove the packaged native macOS app on the desktop.
+- Used sanitized fixture data for source selection, Browse, Overview, Search, date filtering, operational filters, refresh/rebuild, exports, and Audit workflows.
+- Tested app menus including About, New Tab, View toggles, Logs commands, exports, Help, usage guide opening, default source, and recent source restoration.
+- Created `docs/manual-qa-report-2026-05-20.md` with a detailed test plan, verification results, issue tickets, and a follow-up implementation plan.
+- Cleaned generated export artifacts from tracked fixture locations after verification.
+
+### Issues Found
+
+- Native UI smoke can leave the packaged app and child engine running.
+- Source picker and Help usage-guide flows can leave the app process running with no viewer windows.
+- Browse's empty state is misleading when operational filters hide all visible messages.
+- Export save panels can default into the selected log source location.
+- Audit manual path entry did not reliably enable Generate during the accessibility-driven pass.
+
+### Privacy Notes
+
+No raw Codex logs, unsanitized session files, screenshots, recordings, private prompts, export payloads, or secrets were added. The QA report uses sanitized fixture references and redacted path placeholders.
+
+### Verification
+
+- Ran `wt bootstrap`.
+- Ran `npm run check:mac-accessibility`.
+- Ran `npm run smoke:mac-ui` and documented its process-leak failure.
+- Ran fixture CLI summary and project checks.
+- Manually exercised the packaged macOS app with sanitized fixture data.
+
+## 2026-05-20 - Draft LinkedIn Article About Codex Log Viewer
+
+Status: Completed
+Related commit/PR: TBD
+
+### User Messages
+
+> Now I wanna write an article about the creation of this log viewer
+>
+> Let's talk about the user needs: why did we need to create it? Let's talk about the whole iteration process. Let's talk about its capabilities and I want to reference why I believe this is important. I believe the user messages represent their overall user intent and they become a critical item on the other trail for how a program is operating
+>
+> This is going to be a LinkedIn article. It needs to be written in a professional manner. It needs to reflect my position. It needs to sound like it came from me as a person
+>
+> It needs to be the right size and I need it to be in paragraphs not bullets
+>
+> Understand the goal:
+> - Outline what the user needed
+> - Outline why we think it's important
+> - Describe how the app was created and its capabilities and how it will be used in the future
+
+### Interpreted Intent
+
+The user wanted a professional LinkedIn article draft that explains why Codex Log Viewer was needed, how it evolved, what it can do, and why user messages should be treated as an important audit trail for AI-assisted software work.
+
+### Response / Work Done
+
+- Reviewed the repository README, product requirements, audit-trail documentation, usage guide, macOS app plan, changelog, and existing worklog entries to ground the article in the actual project.
+- Drafted `docs/linkedin-log-viewer-article.md` as a paragraph-based LinkedIn article in first person.
+- Framed the article around local-first privacy, user intent, auditability, iteration through real usage, Project Focus classification, and future use.
+
+### Privacy Notes
+
+No raw Codex logs, private session content, local file paths, screenshots, recordings, or customer data were added. The article uses public project concepts and sanitized implementation descriptions.
+
+### Verification
+
+- Documentation-only change; no app rebuild or relaunch was needed.
+
 ## 2026-05-20 - Sync Search Conversation Navigation
 
 Status: Completed
@@ -1043,3 +1200,31 @@ No raw logs or unsanitized session content were added. Classifier tests use synt
 ### Verification
 
 - Ran `npm run test -w @codex-log-viewer/analytics`.
+
+## 2026-05-20 - Prepare Repository Sharing Details
+
+Status: Completed
+Related commit/PR: TBD
+
+### User Messages
+
+> Give me the details so I can share the GitHub repository as part of my open source
+
+### Interpreted Intent
+
+The user wanted concise, public-facing repository details that can be used to share Codex Log Viewer as an open source project.
+
+### Response / Work Done
+
+- Reviewed the local README, package metadata, license, security policy, contributing guide, changelog, and open source readiness notes.
+- Verified the GitHub repository URL, visibility, description, default branch, license, and topics through the GitHub CLI.
+- Prepared share-ready repository details and short announcement copy without exposing private logs or local session data.
+
+### Privacy Notes
+
+No raw logs, private session content, secrets, or unsanitized local Codex data were read or added.
+
+### Verification
+
+- Confirmed the repository is public at `https://github.com/crispierry/codex-log-viewer`.
+- Confirmed the repository uses the MIT License and has privacy/security contribution guidance.

--- a/docs/ai-worklog.md
+++ b/docs/ai-worklog.md
@@ -2,6 +2,206 @@
 
 Sanitized audit trail of AI-assisted work on this project.
 
+## 2026-05-20 - Sync Search Conversation Navigation
+
+Status: Completed
+Related commit/PR: TBD
+
+### User Messages
+
+> When we go from search results and I click Show message, we go back to the other page and we show the right message. However the conversation column is highlighting the wrong conversation. You need to move that to put me in the correct conversation and then show the conversation on the right. Do you understand what I'm saying?
+
+> Make sure that the project is also showing the right scene. Now either go to all projects or go to the relevant project in question
+
+### Interpreted Intent
+
+The user wanted Search's `Show Conversation` action to navigate the whole Browse scene consistently: project scope, message-list highlight, scroll position, and right-hand conversation detail should all point to the same conversation.
+
+### Response / Work Done
+
+- Changed Search result navigation to keep `All Projects` when that is the active scope, or switch to the result's project when Browse is scoped to another project.
+- Added pending conversation navigation so project changes wait for the destination project's summary and message list before selecting the conversation.
+- Synchronized the Browse user-message row to the user prompt that owns the selected search result, including assistant-result hits that resolve to their containing user interaction.
+- Added automatic scrolling in the Browse user-message list so the selected conversation row is brought into view after navigation.
+- Converted the project sidebar selection to route through `AppModel.selectProject` directly instead of a separate `onChange`, so programmatic project navigation does not trigger a second reset.
+- Extended the native UI smoke workflow to assert assistant search-result navigation resolves to the expected user-message highlight.
+- Rebuilt and packaged the macOS app as build 96, then relaunched the packaged app for review.
+
+### Privacy Notes
+
+No raw Codex logs, unsanitized session files, screenshots, recordings, or real local paths were added. Verification uses sanitized fixtures only.
+
+### Verification
+
+- Ran `swift build --package-path apps/macos`.
+- Ran `npm run check:mac-accessibility`.
+- Ran `git diff --check`.
+- Ran `npm run package:mac`.
+- Ran `npm run smoke:mac-package`.
+- Ran `npm run smoke:mac-ui`.
+- Relaunched `dist/macos/Codex Log Viewer.app`.
+
+## 2026-05-20 - Keep Show Sessions Toggle Enabled
+
+Status: Completed
+Related commit/PR: TBD
+
+### User Messages
+
+> Also I'm not able to turn off show sessions once the sessions are being displayed
+
+### Interpreted Intent
+
+The user wanted the `View > Show Sessions` menu toggle to remain enabled after the session browser column is displayed, so the column can be turned off from the same menu.
+
+### Response / Work Done
+
+- Confirmed the menu item was falling back to the disabled command state when the command layer did not have a focused app model.
+- Published each window's `AppModel` as a scene-level focused value in addition to the existing view-level focused value, so transient focus changes inside the split view do not disable the View menu commands.
+- Rebuilt and packaged the macOS app as build 95, then relaunched the packaged app for review.
+
+### Privacy Notes
+
+No raw Codex logs, unsanitized session files, screenshots, recordings, or real local paths were added.
+
+### Verification
+
+- Ran `swift build --package-path apps/macos`.
+- Ran `npm run check:mac-accessibility`.
+- Ran `git diff --check`.
+- Ran `npm run package:mac`.
+- Ran `npm run smoke:mac-package`.
+- Ran `npm run smoke:mac-ui`.
+- Relaunched `dist/macos/Codex Log Viewer.app`.
+- Activated the relaunched app with System Events, toggled `View > Show Sessions` on and off, and confirmed the menu item remained enabled after each toggle.
+
+## 2026-05-20 - Clarify Operational All Toggle
+
+Status: Completed
+Related commit/PR: TBD
+
+### User Messages
+
+> I should be able to select all and see all the check marks right away. Also the list of categories you showed is only a subset. I want to make sure when I'm selecting all you're including all messages. Is that right
+
+### Interpreted Intent
+
+The user wanted the operational `All` toggle to visibly update every category checkbox immediately and wanted confirmation that selecting `All` restores the full in-scope message list, not only a subset of operational categories.
+
+### Response / Work Done
+
+- Updated repeated-prompt and operational filter setters to assign fresh category sets after changes, giving SwiftUI a direct state update for immediate menu checkmark refresh.
+- Clarified the native help text and usage guide: checked `All` hides no operational category, so all messages matching the current app filters are visible; unchecked `All` hides only the operational families listed in the menu.
+- Rebuilt and packaged the macOS app as build 94, then relaunched the packaged app for review.
+
+### Privacy Notes
+
+No raw Codex logs, unsanitized session files, screenshots, recordings, or real local paths were added.
+
+### Verification
+
+- Ran `swift build --package-path apps/macos`.
+- Ran `npm run check:mac-accessibility`.
+- Ran `git diff --check`.
+- Ran `npm run package:mac`.
+- Ran `npm run smoke:mac-package`.
+- Ran `npm run smoke:mac-ui`.
+- Relaunched `dist/macos/Codex Log Viewer.app`.
+
+## 2026-05-20 - Align Operational Filters With Project Focus Categories
+
+Status: Completed
+Related commit/PR: TBD
+
+### User Messages
+
+> I just ran into a bug when I said "view operational messages" and all is not working anymore so we need to address that
+>
+> Can you figure out what happened? I believe our new content classification messed that up so see if that's still appropriate and what categories we need to include
+>
+> It's something where we need to include or exclude some of those categories
+
+### Interpreted Intent
+
+The user wanted the `View > Operational Messages` menu fixed after the newer Project Focus classifier introduced category labels that the older operational filter did not know how to hide.
+
+### Response / Work Done
+
+- Traced operational filtering across analytics, the local API, Browse/Search/session detail visibility, repeated prompt groups, and the native View menu.
+- Replaced the older narrow operational classifier with an explicit operational subset of Project Focus categories: `Code review/QA`, `Deploy/release`, `Git commands`, `Plan approvals`, `Run/build app`, and `Testing/verification`.
+- Updated the native View menu to expose those categories and made the `All` toggle hide every operational category.
+- Added settings migration for older saved labels such as `Code review` and `Run app`, including the previous deploy-as-Git behavior for legacy saved filters.
+- Expanded analytics and native smoke coverage so all operational categories can be hidden together.
+- Updated the usage guide and native help text to document the revised include/exclude behavior.
+- Rebuilt and packaged the macOS app as build 93, then relaunched the packaged app for review.
+
+### Privacy Notes
+
+No raw Codex logs, unsanitized session files, screenshots, recordings, or real local paths were added. New coverage uses synthetic fixture messages only.
+
+### Verification
+
+- Ran `npm run test -w @codex-log-viewer/analytics`.
+- Ran `npm run build -w @codex-log-viewer/analytics`.
+- Ran `npm test`.
+- Ran `npm run lint`.
+- Ran `npm run privacy:scan`.
+- Ran `npm run check:mac-accessibility`.
+- Ran `git diff --check`.
+- Ran `npm run check:reference -- --reference fixtures/codex/sample-reference-summary.json --path fixtures/codex/sample-session.jsonl --project sample-app`.
+- Ran `npm run package:mac`.
+- Ran `npm run smoke:mac-package`.
+- Ran `npm run smoke:mac-ui`.
+- Relaunched `dist/macos/Codex Log Viewer.app`.
+
+## 2026-05-20 - Final Open Source Readiness Pass
+
+Status: Completed
+Related commit/PR: TBD
+
+### User Messages
+
+> I'm pretty happy with all the changes. The app looks good. I'm getting ready to open source this effort. I need you to do a final complete pass of all the documentation and all the source code make sure this is ready for open source.
+
+### Interpreted Intent
+
+The user wanted a final public-readiness audit across documentation, source code, packaging, privacy posture, and verification before opening the repository.
+
+### Response / Work Done
+
+- Reviewed the repository instructions, public docs, fixtures, TypeScript parser/analytics/server/CLI code, native macOS app code, packaging scripts, workflows, and release materials.
+- Added `.codex/` to `.gitignore` so local audit drafts and raw transcripts match the documented local-only workflow.
+- Updated the fixture README to list the visual image-evidence fixture.
+- Clarified the privacy scan scope as tracked and non-ignored untracked files.
+- Removed a branch-specific PR reference from the first public release plan and refreshed its review date.
+- Updated CLI help so the `sessions` command documents `--path`.
+- Changed the packaging script so required notarization settings are validated before the app build number is bumped.
+- Scoped the native session inspector's submitted and automation messages to the selected daily session slice when a date-scoped session is selected.
+- Rebuilt and packaged the macOS app as build 92, then relaunched the packaged app for review.
+
+### Privacy Notes
+
+No raw Codex logs, private session files, screenshots, recordings, or real local paths were added. The new ignore rule reduces the chance of local audit material being accidentally committed.
+
+### Verification
+
+- Ran `wt bootstrap`.
+- Ran `npm run privacy:scan`.
+- Ran `npm run lint`.
+- Ran `npm test`.
+- Ran `npm run check:mac-accessibility`.
+- Ran `npm audit --audit-level=moderate`.
+- Ran a local Markdown link-resolution check.
+- Ran `npm run benchmark:search`.
+- Ran `npm run check:reference -- --reference fixtures/codex/sample-reference-summary.json --path fixtures/codex/sample-session.jsonl --project sample-app`.
+- Ran `git diff --check`.
+- Ran `npm run package:mac`.
+- Ran `npm run smoke:mac-package` after closing a pre-existing packaged app instance.
+- Ran `npm run smoke:mac-ui`.
+- Ran `npm run release:notes -- --tag v0.1.0 --output dist/macos/release-notes.md`.
+- Ran checksum verification for the packaged macOS archives, including build 92.
+- Relaunched `dist/macos/Codex Log Viewer.app`.
+
 ## 2026-05-19 - Rename Messages Column Label
 
 Status: Completed

--- a/docs/first-public-release-plan.md
+++ b/docs/first-public-release-plan.md
@@ -2,7 +2,7 @@
 
 This plan tracks the remaining work before Codex Log Viewer is ready for a first public version. It assumes the first public version is a native macOS release, not a web app, and that local Codex logs stay on the user's machine by default.
 
-Last reviewed: 2026-05-19
+Last reviewed: 2026-05-20
 
 ## Release Definition
 
@@ -49,7 +49,7 @@ External release prerequisites:
 
 - Developer ID certificate and notarytool keychain profile are required to produce a notarized public macOS artifact.
 - A maintainer should run the private-log parity check locally with a private reference report, without committing private inputs or outputs.
-- PR #8 is blocked only on the configured review requirement before merge/tag.
+- The release branch still needs the configured human review before merge/tag.
 
 ## Current Completion Audit
 

--- a/docs/manual-qa-fix-plan-2026-05-20.md
+++ b/docs/manual-qa-fix-plan-2026-05-20.md
@@ -1,0 +1,248 @@
+# Manual QA Fix Plan - 2026-05-20
+
+## Goal
+
+Fix every issue documented in `docs/manual-qa-report-2026-05-20.md`, with stability first, then user-facing correctness, then export and Audit workflow polish. The work should remain fixture-driven and privacy-conscious.
+
+## Guiding Principles
+
+- Do not use raw local Codex logs for regression coverage.
+- Prefer native UI smoke coverage for window lifecycle, source selection, search, export, and Audit regressions.
+- Keep manual QA artifacts out of tracked fixture directories.
+- Preserve app-local parsing and redacted export defaults.
+- Rebuild, package, smoke test, and relaunch the packaged app after user-visible native changes.
+
+## Execution Order
+
+1. Fix native smoke cleanup and process lifecycle.
+2. Fix window lifecycle around source picker and external help/docs.
+3. Add regression coverage for those lifecycle paths.
+4. Fix misleading operational-filter empty state.
+5. Fix export save-panel defaults and destination memory.
+6. Fix Audit manual path entry.
+7. Run full verification and a short manual regression pass.
+
+## Phase 1 - Stabilize UI Smoke Cleanup
+
+Issues covered:
+
+- QA-001 - Native UI Smoke Leaves App And Engine Processes Running
+
+Likely files:
+
+- `scripts/smoke-native-ui.mjs`
+- `apps/macos/Sources/CodexLogViewerMac/AppModel.swift`
+- `apps/macos/Sources/CodexLogViewerMac/CodexLogViewerApp.swift`
+
+Plan:
+
+1. Reproduce `npm run smoke:mac-ui` from a clean packaged app state.
+2. Make `scripts/smoke-native-ui.mjs` always run cleanup before asserting leaks:
+   - request app quit
+   - wait briefly for app and engine exit
+   - kill the launched child process if needed
+   - only then run leak detection
+3. Scope leak detection to the app path launched by the smoke test so unrelated running builds do not create false failures.
+4. Review `scheduleUITestWorkflowIfNeeded` to confirm the smoke workflow reaches `NSApp.terminate(nil)` on success and stops the engine on failure.
+5. Add diagnostic output when auto-quit does not happen, including app exit code, signal, stdout, stderr, and remaining process list.
+
+Acceptance criteria:
+
+- `npm run smoke:mac-ui` passes.
+- A forced smoke failure does not leave the packaged app or bundled engine running.
+- Leak assertions still fail when a process truly remains after cleanup.
+
+## Phase 2 - Fix Main Window Lifecycle
+
+Issues covered:
+
+- QA-002 - Source Picker Can Leave The App Running With No Viewer Windows
+- QA-003 - Opening The Usage Guide Can Leave The App Running With No Viewer Windows
+
+Likely files:
+
+- `apps/macos/Sources/CodexLogViewerMac/AppModel.swift`
+- `apps/macos/Sources/CodexLogViewerMac/CodexLogViewerApp.swift`
+- `scripts/smoke-native-ui.mjs`
+
+Plan:
+
+1. Reproduce both no-window cases with the packaged app and sanitized fixture:
+   - `Logs > Choose Codex Log Location... > sample-session.jsonl > Choose`
+   - `Help > Codex Log Viewer Help > Open Usage Guide`
+2. Identify whether the window is closing, hiding, moving to another space, or losing its accessibility registration.
+3. Add a small main-window restoration helper in the app layer if needed:
+   - ensure there is an ordered-front viewer window after modal panels dismiss
+   - activate the app after source selection and after returning from help/docs actions
+   - avoid creating duplicate windows when a viewer window already exists
+4. For source picking, make `chooseSourcePaths()` explicitly return focus to the viewer after `setSourcePaths(...)`.
+5. For help/docs, avoid letting the help alert or `NSWorkspace.shared.open(...)` leave the app with no viewer window.
+6. Add smoke coverage that checks window count after source selection and usage-guide opening.
+
+Acceptance criteria:
+
+- Selecting a source returns to a visible viewer window with the selected data loaded.
+- Opening the usage guide does not remove the main viewer window.
+- The app remains reachable from the Dock/App Switcher with a visible window.
+- Regression coverage fails if window count drops to zero after these flows.
+
+## Phase 3 - Correct Browse Empty States For Operational Filters
+
+Issues covered:
+
+- QA-004 - Operational Filter Empty State Is Misleading In Browse
+
+Likely files:
+
+- `apps/macos/Sources/CodexLogViewerMac/RootView.swift`
+- `apps/macos/Sources/CodexLogViewerMac/AppModel.swift`
+
+Plan:
+
+1. Add a model helper for the project-level Browse list, such as `areBrowseMessagesHiddenByOperationalFilters`.
+2. In `projectMessagesContent`, distinguish:
+   - no submitted messages exist in the current source/project/date scope
+   - submitted messages exist, but current operational filters hide all visible rows
+3. Reuse the clearer session-level wording:
+   - title: `No Visible Messages`
+   - description: `Turn on at least one operational message family in the View menu.`
+4. Confirm status text continues to show `0 visible of N sent`.
+5. Extend native UI smoke or model workflow smoke to hide `Testing/verification` and assert the project-level empty-state copy.
+
+Acceptance criteria:
+
+- Hiding the only operational category no longer claims there are no matching submitted messages.
+- The empty state points the user to the View menu.
+- The fix works with the session browser both hidden and visible.
+
+## Phase 4 - Make Export Destinations Safer
+
+Issues covered:
+
+- QA-005 - Export Save Panels Default Into The Current Log Source Location
+
+Likely files:
+
+- `apps/macos/Sources/CodexLogViewerMac/AppModel.swift`
+- `apps/macos/Sources/CodexLogViewerMac/Models.swift` if a new default key is useful
+- `scripts/smoke-native-ui.mjs` or a future export smoke helper
+
+Plan:
+
+1. Add a dedicated export directory setting that is separate from log source paths.
+2. Choose a safer default destination:
+   - previously used export directory, if available
+   - otherwise `~/Downloads`
+   - otherwise the user's home directory
+3. Set `NSSavePanel.directoryURL` before presenting the panel.
+4. After a successful export, persist the selected destination directory.
+5. Consider a small guardrail when the destination sits inside `sourcePaths`:
+   - either warn the user
+   - or simply avoid defaulting there while still allowing an intentional choice
+6. Keep JSON's redaction warning unchanged.
+7. Add coverage at least at the model/helper level for resolving export directories; add UI smoke if practical.
+
+Acceptance criteria:
+
+- JSON and CSV save panels no longer default into fixture/source folders.
+- Repeated exports default to the last chosen export directory.
+- Export files are still written correctly and JSON stays redacted by default.
+
+## Phase 5 - Fix Audit Manual Path Entry
+
+Issues covered:
+
+- QA-006 - Manual Audit Path Entry Does Not Enable Generate Reliably
+
+Likely files:
+
+- `apps/macos/Sources/CodexLogViewerMac/RootView.swift`
+- `apps/macos/Sources/CodexLogViewerMac/AppModel.swift`
+
+Plan:
+
+1. Reproduce direct typing and paste into the Audit repository field.
+2. Replace the direct `$model.auditRepoPathDraft` binding with an explicit binding if needed:
+   - getter returns `auditRepoPathDraft`
+   - setter calls a model method such as `setAuditRepoPathDraft(_:)`
+3. In the setter method:
+   - update the published path
+   - clear the preview
+   - clear stale status messages where appropriate
+   - avoid clearing preview repeatedly when the value has not changed
+4. Decide whether `canGenerateAudit` should require only non-empty text or also an existing directory.
+5. Add smoke coverage for manual text entry enabling Generate before picker selection.
+
+Acceptance criteria:
+
+- Typing or pasting a valid repository path enables Generate.
+- Picker selection continues to enable Generate.
+- Changing the path clears stale preview data.
+- Invalid or empty paths keep Generate disabled if validation is added.
+
+## Phase 6 - Regression Coverage Expansion
+
+Issues covered:
+
+- All QA tickets
+
+Likely files:
+
+- `scripts/smoke-native-ui.mjs`
+- `scripts/check-native-accessibility.mjs`
+- `apps/macos/Sources/CodexLogViewerMac/AppModel.swift`
+- `apps/macos/Sources/CodexLogViewerMac/CodexLogViewerApp.swift`
+
+Plan:
+
+1. Add accessibility identifiers if any new controls or messages need stable targeting.
+2. Extend the native UI smoke path to cover:
+   - source picker completes with window still visible
+   - usage guide opening does not remove viewer window
+   - operational filter hidden state shows correct empty text
+   - Audit manual path entry enables Generate
+3. Keep export-write assertions fixture-safe:
+   - write into a temporary ignored destination
+   - remove artifacts after verification
+4. Keep smoke tests deterministic with sanitized fixtures and ephemeral settings.
+
+Acceptance criteria:
+
+- Existing smoke coverage still passes.
+- New smoke coverage fails for each previously observed regression.
+- No tracked fixture export artifacts are left behind after tests.
+
+## Final Verification Checklist
+
+Run from a bootstrapped worktree:
+
+```sh
+wt bootstrap
+npm run check:mac-accessibility
+npm run smoke:mac-ui
+npm run smoke:mac-package
+npm run package:mac
+npm run smoke:mac-ui
+git diff --check
+```
+
+For the final user-visible native app pass:
+
+1. Relaunch `dist/macos/Codex Log Viewer.app`.
+2. Select the sanitized fixture source.
+3. Confirm source selection keeps a visible window.
+4. Open Help and usage guide, then return to a visible app window.
+5. Hide and restore `Testing/verification`; confirm Browse empty-state copy.
+6. Export JSON and CSV into a safe temporary destination.
+7. Type an Audit repository path manually and confirm Generate enables.
+8. Generate and approve an Audit preview into a temporary ignored repository.
+
+## Release Notes For The Fix Pass
+
+When implementation is complete, summarize the fixes as:
+
+- Improved native UI smoke cleanup and process leak detection.
+- Fixed viewer-window restoration after source and help/documentation flows.
+- Clarified Browse empty states when operational filters hide messages.
+- Moved export defaults away from log source folders.
+- Fixed Audit repository path entry so manual input and picker input behave consistently.

--- a/docs/manual-qa-report-2026-05-20.md
+++ b/docs/manual-qa-report-2026-05-20.md
@@ -1,0 +1,276 @@
+# Manual macOS QA Report - 2026-05-20
+
+## Scope
+
+This pass exercised the packaged native macOS app as a power-user workflow, using sanitized fixture data instead of raw local Codex logs.
+
+Primary fixture source:
+
+- `<repo>/fixtures/codex/sample-session.jsonl`
+
+Temporary write targets:
+
+- ignored export files created during the pass and removed afterward
+- `<tmp>/codex-log-viewer-qa-audit-repo/docs/ai-worklog.md`
+
+No raw local session logs, private prompts, screenshots, or export payloads were added to the repository.
+
+## Test Plan
+
+### Launch And Baseline
+
+- Bootstrap the worktree before local verification.
+- Launch the packaged macOS app from `dist/macos/Codex Log Viewer.app`.
+- Confirm the main window appears and the local engine starts.
+- Load the sanitized fixture through `Logs > Choose Codex Log Location...`.
+- Confirm the sidebar, header metrics, cache status, project list, and selected source all update.
+
+### Menus
+
+- App menu: open About.
+- File menu: create a new tab and close it.
+- View menu: toggle `Show Sessions`.
+- View menu: toggle `Operational Messages > All`.
+- View menu: toggle each operational category.
+- Logs menu: inspect Status, Refresh, Rebuild Local Cache, Find in Messages, Search Messages, source picker, default source, recent source, JSON export, and CSV export.
+- Help menu: open help and open the usage guide.
+
+### Browse
+
+- Select `All Projects`.
+- Select the fixture project.
+- Toggle the session browser on and off.
+- Select a session.
+- Select a sent user message.
+- Confirm the interaction pane shows the matching user message, assistant response, token counts, duration, and first-token timing.
+- Confirm operational-category filtering updates visible message counts.
+
+### Overview
+
+- Open Overview.
+- Verify metric cards for sessions, sent messages, automations, unique messages, total tokens, fresh/cached input, output, and reasoning.
+- Verify Project Focus category summary.
+- Verify charts render without blocking the rest of the UI.
+
+### Search
+
+- Focus search from the Logs menu.
+- Search for `parser`.
+- Verify user-role search returns the fixture user message.
+- Select a search result.
+- Verify selected-result metadata and preview.
+- Use copy actions for session id, project, and matched text.
+- Use `Show Conversation` and confirm Browse opens the matching interaction.
+- Test role filters: All, User Sent, Automation, Assistant, System, Developer.
+- Test the model filter with `gpt-5.5` and `All Models`.
+- Click search-table sort headers.
+
+### Date Filters
+
+- Open the date-range popover.
+- Select All Time, Day, Week, Month, Year, and Custom.
+- Clear the filter and confirm All Time is restored.
+
+### Exports
+
+- Export redacted JSON and confirm the privacy warning appears.
+- Confirm JSON export writes parseable summary data and does not include raw local user paths.
+- Export CSV and confirm the save panel writes a file.
+- Remove generated export files from tracked fixture locations after verification.
+
+### Audit
+
+- Open Audit.
+- Choose a temporary repository.
+- Toggle `Responses`.
+- Generate an audit preview.
+- Approve the preview into the temporary worklog.
+- Confirm the saved status message and written file.
+
+## Verification Results
+
+- `wt bootstrap` completed successfully.
+- `npm run check:mac-accessibility` passed for 39 controls.
+- `npm run smoke:mac-ui` failed because the smoke run left the packaged app and child engine running.
+- CLI fixture summary confirmed the selected fixture has 1 session, 1 user message, 1 assistant message, 17,277 total tokens, 1 unknown event, and 1 parse warning.
+- Manual fixture loading, Browse, Overview, Search, date filters, View filters, refresh/rebuild, recent-source restore, JSON export, CSV save, Audit preview, and Audit save were exercised.
+
+## Issue Tickets
+
+### QA-001 - Native UI Smoke Leaves App And Engine Processes Running
+
+Severity: High
+
+Status: Reproducible during this pass
+
+Observed:
+
+- `npm run smoke:mac-ui` failed with a leaked packaged app process and a leaked bundled engine process.
+- The app remained running after the smoke script expected it to quit.
+
+Expected:
+
+- The smoke script should either drive the app to a clean exit or terminate the launched app and child engine before asserting no leaks.
+
+Repro:
+
+1. Run `npm run smoke:mac-ui`.
+2. Observe the failure reporting remaining app and engine processes.
+
+Implementation notes:
+
+- Inspect the auto-quit path in `scripts/smoke-native-ui.mjs` and the app's `CODEX_LOG_VIEWER_UI_TEST_AUTO_QUIT` / workflow smoke handling.
+- Add a stronger cleanup path in the smoke script so failed UI assertions do not leave processes behind.
+- Preserve the existing child-engine leak assertion, but make cleanup deterministic before the final assertion.
+
+### QA-002 - Source Picker Can Leave The App Running With No Viewer Windows
+
+Severity: High
+
+Status: Reproducible during this pass
+
+Observed:
+
+- After selecting `sample-session.jsonl` from `Logs > Choose Codex Log Location...`, the source was accepted, but the app process remained with zero visible windows.
+- Relaunching the app showed the selected fixture source and loaded the expected data.
+
+Expected:
+
+- Choosing a source should dismiss the picker and return to the existing viewer window with the scan result visible.
+
+Repro:
+
+1. Open the packaged app.
+2. Choose a fixture file from `Logs > Choose Codex Log Location...`.
+3. Click `Choose`.
+4. Check whether the main viewer window remains visible.
+
+Implementation notes:
+
+- Review `NSOpenPanel.runModal()` usage in `AppModel.chooseSourcePaths()`.
+- Check whether panel dismissal or focus restoration is interacting with `WindowGroup` lifecycle.
+- Add a manual or automated regression that verifies `count of windows` remains at least 1 after source selection.
+
+### QA-003 - Opening The Usage Guide Can Leave The App Running With No Viewer Windows
+
+Severity: High
+
+Status: Reproducible during this pass
+
+Observed:
+
+- From the Help alert, clicking `Open Usage Guide` opened the external guide target but left the packaged app process with zero visible windows.
+
+Expected:
+
+- Opening documentation should keep the viewer window alive and returnable.
+
+Repro:
+
+1. Open `Help > Codex Log Viewer Help`.
+2. Click `Open Usage Guide`.
+3. Return to Codex Log Viewer and check whether the main window still exists.
+
+Implementation notes:
+
+- Review `AppModel.openUsageGuide()` and any activation/focus behavior around `NSWorkspace.shared.open`.
+- Consider opening documentation without closing or invalidating the app's only viewer window.
+- Add a UI smoke assertion that `Help > Open Usage Guide` does not remove the main window.
+
+### QA-004 - Operational Filter Empty State Is Misleading In Browse
+
+Severity: Medium
+
+Status: Reproducible during this pass
+
+Observed:
+
+- Hiding the `Testing/verification` operational category removed the only visible user message.
+- The middle Browse column showed `No Sent Messages` with copy saying no submitted messages match the selected project/date filters.
+- The status bar correctly said `0 visible of 1 sent`.
+
+Expected:
+
+- When messages exist but are hidden by operational filters, the empty state should say that filters are hiding messages and point the user to `View > Operational Messages`.
+
+Repro:
+
+1. Load the sample fixture.
+2. Stay in Browse with the session browser hidden.
+3. Turn off `View > Operational Messages > Testing/verification`.
+4. Observe the empty state.
+
+Implementation notes:
+
+- `SessionMessagesView` already has clearer language for hidden operational messages.
+- Apply similar hidden-filter awareness to the project-level Browse message list.
+
+### QA-005 - Export Save Panels Default Into The Current Log Source Location
+
+Severity: Medium
+
+Status: Reproducible during this pass
+
+Observed:
+
+- With the fixture file selected as the source, JSON and CSV export save panels defaulted into the fixture/source location.
+- This made it easy to write generated export files into a tracked source-data directory.
+
+Expected:
+
+- Exports should default to a safer user output location, such as the last export destination, Downloads, or an app-controlled export folder.
+
+Repro:
+
+1. Select a fixture or source directory.
+2. Run `Logs > Export Redacted JSON...` or `Logs > Export CSV...`.
+3. Observe the default save location.
+
+Implementation notes:
+
+- Set `NSSavePanel.directoryURL` explicitly.
+- Remember the last export directory separately from log source paths.
+- Consider warning if the destination is inside a known source path.
+
+### QA-006 - Manual Audit Path Entry Does Not Enable Generate Reliably
+
+Severity: Medium
+
+Status: Reproducible during this pass through accessibility-driven entry
+
+Observed:
+
+- Entering the temporary repository path into the Audit text field left `Generate` disabled even though the visible field contained a valid path.
+- Choosing the same repository through `Choose Repository` enabled `Generate`.
+
+Expected:
+
+- Manual text entry and picker-based selection should both update `auditRepoPathDraft` and enable `Generate`.
+
+Repro:
+
+1. Open Audit.
+2. Type or paste a valid repository path into the repository path field.
+3. Observe whether `Generate` enables.
+4. Use `Choose Repository` for the same path and compare behavior.
+
+Implementation notes:
+
+- Validate the SwiftUI `TextField` binding and `onChange` behavior for direct keyboard entry, paste, and accessibility value setting.
+- Add an accessibility or unit-level test for direct path entry enabling the Generate button.
+
+## Follow-Up Implementation Plan
+
+1. Fix process cleanup in `smoke-native-ui.mjs` and confirm `npm run smoke:mac-ui` passes without leaked app or engine processes.
+2. Investigate the shared window-lifecycle failure after source selection and usage-guide opening.
+3. Add UI regression checks for window presence after source picker and Help usage-guide flows.
+4. Improve Browse empty-state copy when operational filters hide all messages.
+5. Set an explicit, safe default export directory and remember the last export destination.
+6. Fix Audit manual path-entry state propagation and add coverage.
+7. Re-run `npm run check:mac-accessibility`, `npm run smoke:mac-ui`, and a focused manual source/export/Audit pass.
+
+## Notes
+
+- The app was left open at the end of the pass for review.
+- Generated fixture export files were removed.
+- The temporary audit test repository is outside the project tree.

--- a/docs/open-source-readiness.md
+++ b/docs/open-source-readiness.md
@@ -9,7 +9,7 @@ This project is safe to prepare as a public repository when this checklist stays
 - CI verifies the TypeScript parser, analytics, private API engine, CLI, macOS Swift build, packaged app smoke path, and native UI smoke path.
 - Generated folders such as `node_modules`, `dist`, `.build`, coverage, and local caches are ignored.
 - The root package is marked private so the monorepo is not accidentally published to npm.
-- `npm run privacy:scan` checks tracked and untracked files for real Codex log paths, local artifacts, signing material, private keys, token-like values, and non-example macOS home paths.
+- `npm run privacy:scan` checks tracked and non-ignored untracked files for real Codex log paths, local artifacts, signing material, private keys, token-like values, and non-example macOS home paths.
 
 ## Privacy Gate
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -54,7 +54,9 @@ Browse lists prompts you typed and submitted for the selected project without re
 
 In Browse, the sidebar selects the project, the main Messages column lists submitted prompts for the current project and date filters, and the Codex Interaction column shows the selected message split into user message, Codex response, tool activity, system/developer context, and token/timing sections. User messages show their Project Focus category label anywhere they appear. Use `View > Show Sessions` when you want an extra session column before the message list.
 
-Use `View > Operational Messages` to hide or show all operational prompt families at once, or control families independently: `Code review`, `Git commands`, `Plan approvals`, and `Run app`. The same operational filters apply in Browse, optional session-message lists, Search results, and repeated prompts.
+Use `View > Operational Messages` to hide or show all operational prompt families at once, or control families independently: `Code review/QA`, `Deploy/release`, `Git commands`, `Plan approvals`, `Run/build app`, and `Testing/verification`. The same operational filters apply in Browse, optional session-message lists, Search results, and repeated prompts.
+
+When `All` is checked, no operational family is hidden, so the app shows all messages that match the current project, date, role, model, session, and search filters. Unchecking `All` hides only the operational families listed in that menu; non-operational Project Focus categories remain visible.
 
 The native macOS tab bar is hidden while there is only one viewer tab. Use `File > New Tab` when you want another app tab; each tab keeps its own project, date, filter, search, and selection state, and the tab bar appears once multiple tabs are open.
 
@@ -133,13 +135,15 @@ You can pass multiple `--path` values.
 
 - User-message counts come from `event_msg.user_message`.
 - Unique user messages are trimmed, whitespace-collapsed, and lowercased.
-- Project Focus classifies submitted user messages into deterministic local categories such as `Feature design`, `Implementation`, `Bug fixes`, `Git commands`, `Deploy/release`, `Planning/strategy`, `Research`, `Content creation`, `Data/metrics`, `Documentation`, and `Feedback/context`.
+- Project Focus classifies submitted user messages into deterministic local categories such as `Feature design`, `Implementation`, `Bug fixes`, `Git commands`, `Deploy/release`, `Run/build app`, `Code review/QA`, `Planning/strategy`, `Research`, `Testing/verification`, `Content creation`, `Data/metrics`, `Documentation`, and `Feedback/context`.
 - Project Focus percentages are based on the current project and date filters, with representative examples shown only inside the local app or non-redacted exports.
 - Repeated prompts are still grouped from normalized user messages in the analytics API and shown only for groups with more than one submission.
 - Short approvals such as `yes`, `go ahead`, `execute`, `do that`, or `sounds good` are grouped as `Plan approvals`.
-- Short Git workflow requests such as commit, push, publish, deploy to production, branch, PR, worktree, or repo-cleanliness checks are grouped as `Git commands`.
-- Short app launch requests such as run, start, restart, launch, or open the app/server are grouped as `Run app`.
-- Short review requests such as `do a code review`, `review the diff`, or `inspect the changes` are grouped as `Code review`.
+- Git workflow requests such as commit, push, branch, PR, worktree, or repo-cleanliness checks are grouped as `Git commands`.
+- Deploy, publish, release, notarization, and production-shipping requests are grouped as `Deploy/release`.
+- App launch, local server, build, package, rebuild, relaunch, and restart requests are grouped as `Run/build app`.
+- Code review, diff review, implementation audit, and QA-finding prompts are grouped as `Code review/QA`.
+- Test, lint, typecheck, smoke test, accessibility, Playwright, screenshot check, and verification prompts are grouped as `Testing/verification`.
 - Browse, Search, and operational prompt groups can hide or show grouped prompt families from the `View > Operational Messages` menu.
 - Token totals sum `token_count.info.last_token_usage` records.
 - `token_count` events with `info: null` are ignored for token totals.

--- a/fixtures/codex/README.md
+++ b/fixtures/codex/README.md
@@ -12,3 +12,4 @@ See [Fixture Guidelines](../../docs/fixture-guidelines.md).
 - `event-shapes.jsonl`: synthetic coverage for response items, tool events, generated browser context, automation messages, token usage, and unknown events.
 - `interaction-detail.jsonl`: synthetic coverage for reconstructing a selected user prompt with Codex response, tool activity, context messages, tokens, and timing.
 - `visual-comment-wrapper.jsonl`: synthetic coverage for extracting real visual review comments while ignoring generated image-caption wrapper text.
+- `visual-comment-image-evidence.jsonl`: synthetic coverage for extracting visual review comments when generated image-evidence text follows the request marker.

--- a/packages/analytics/src/summary.ts
+++ b/packages/analytics/src/summary.ts
@@ -17,6 +17,7 @@ import type {
   MessageSearchResult,
   MessageSearchSummary,
   ModelBucket,
+  PromptIntentCategory,
   PromptIntentSummary,
   ProjectAlias,
   ProjectListItem,
@@ -26,6 +27,15 @@ import type {
   SummaryOptions
 } from "./types.js";
 import { addUsage, emptyUsage } from "./usage.js";
+
+const operationalPromptIntentCategoryKeys = new Set<string>([
+  promptIntentCategories.codeReviewQa.key,
+  promptIntentCategories.deployRelease.key,
+  promptIntentCategories.gitCommands.key,
+  promptIntentCategories.planApprovals.key,
+  promptIntentCategories.runBuildApp.key,
+  promptIntentCategories.testingVerification.key
+]);
 
 export async function loadCorpus(options: SummaryOptions = {}): Promise<LoadedCorpus> {
   if (options.cacheDir) {
@@ -613,92 +623,9 @@ export function userMessageCategoryLabel(message: string): string | undefined {
   return userMessageCategory(normalizeLiteralMessage(message))?.label;
 }
 
-function userMessageCategory(normalized: string): { key: string; label: string } | undefined {
-  if (isPlanApprovalMessage(normalized)) {
-    return { key: "plan-approvals", label: "Plan approvals" };
-  }
-
-  const commandText = normalizedCommandText(normalized);
-  if (isGitCommandMessage(commandText)) {
-    return { key: "git-commands", label: "Git commands" };
-  }
-  if (isRunAppMessage(commandText)) {
-    return { key: "run-app", label: "Run app" };
-  }
-  if (isCodeReviewMessage(commandText)) {
-    return { key: "code-review", label: "Code review" };
-  }
-  return undefined;
-}
-
-function isPlanApprovalMessage(normalized: string): boolean {
-  if (normalized.length > 70) {
-    return false;
-  }
-  const value = normalized
-    .replace(/[.!]+$/u, "")
-    .replace(/\s*,\s*/gu, ", ")
-    .trim();
-  const oneWordApproval = /^(yes|yeah|yep|yup|sure|ok|okay|approved|confirmed|execute)$/u.test(value);
-  const shortApproval =
-    /^(yes|yeah|yep|yup|sure|ok|okay),? (please|go ahead|proceed|do it|sounds good|let's do it|lets do it)$/u.test(value);
-  const phraseApproval =
-    /^(sounds good|looks good|that works|works for me|go ahead|please do|do it|do that|proceed|approved|confirmed|ship it|let's do it|lets do it|execute it|execute that|execute this|execute the plan|execute the changes)( please)?$/u.test(value);
-  return oneWordApproval || shortApproval || phraseApproval;
-}
-
-function normalizedCommandText(normalized: string): string {
-  let value = normalized;
-  let changed = true;
-  while (changed) {
-    const previous = value;
-    value = value
-      .replace(/^(ok|okay)[, ]+/, "")
-      .replace(/^(please|pls)[, ]+/, "")
-      .replace(/^(can|could|would) you\s+/, "")
-      .replace(/^let'?s\s+/, "");
-    changed = value !== previous;
-  }
-  return value.replace(/\s+(please|for me)$/u, "").trim();
-}
-
-function isGitCommandMessage(normalized: string): boolean {
-  if (normalized.length > 120) {
-    return false;
-  }
-  const directGitCommand =
-    /^(git )?(commit|push|merge|rebase|branch|checkout|switch|pull|fetch|stash|tag|open pr|create pr|close pr|merge pr)\b/.test(normalized);
-  const publishCommand =
-    /^(publish|deploy)( (it|this|the app|the build|the release|the site|the website|to (main|origin|github|production|prod|release)|production|prod))?$/u.test(normalized);
-  const explicitGitInspection = /^git (status|diff|log)\b/.test(normalized);
-  const gitObjectAction =
-    /^(create|make|open|merge|close|delete|remove|clean|switch|checkout) ((a|the|current|new) )*(branch|commit|pull request|pr|worktree|work tree)\b/.test(normalized);
-  const worktreeCleanup = /^(close|delete|remove|clean) ((the|current) )*(worktree|work tree)\b/.test(normalized);
-  const commitStateQuestion =
-    /^(are|is|did|do|does|have|has)\b.*\b(all|everything|files?|changes?|work|worktree|work tree|repo|repository|anything|we)\b.*\b(committed|commit|pushed|push|staged|unstaged|uncommitted|dirty|clean)\b\??$/.test(normalized) ||
-    /^(all|everything|files?|changes?|anything|repo|repository|worktree|work tree)\b.*\b(committed|pushed|staged|unstaged|uncommitted|dirty|clean)\b\??$/.test(normalized);
-  return directGitCommand || publishCommand || explicitGitInspection || gitObjectAction || worktreeCleanup || commitStateQuestion;
-}
-
-function isRunAppMessage(normalized: string): boolean {
-  if (normalized.length > 140) {
-    return false;
-  }
-  const appLaunchCommand =
-    /^(run|start|restart|launch|open) (the )?(app|application|desktop app|mac app|macos app|native app|packaged app|server|local server|dev server|development server)\b/.test(normalized);
-  const devServerCommand = /^(run|start|restart) (npm run dev|dev|desktop|local app)\b/.test(normalized);
-  return appLaunchCommand || devServerCommand;
-}
-
-function isCodeReviewMessage(normalized: string): boolean {
-  if (normalized.length > 160) {
-    return false;
-  }
-  const reviewCommand =
-    /^(code review|do a code review|run a code review|review code|review the code|review this code|review the diff|review the changes)\b/.test(normalized);
-  const reviewTarget =
-    /^(review|inspect|audit) (the )?(code|diff|changes|change set|pull request|pr)\b/.test(normalized);
-  return reviewCommand || reviewTarget;
+function userMessageCategory(normalized: string): PromptIntentCategory | undefined {
+  const promptIntent = classifyPromptIntent(normalized);
+  return operationalPromptIntentCategoryKeys.has(promptIntent.key) ? promptIntent : undefined;
 }
 
 function repeatedMessageId(normalized: string): string {

--- a/packages/analytics/test/summary.test.mjs
+++ b/packages/analytics/test/summary.test.mjs
@@ -235,7 +235,11 @@ test("summarizeParsedCorpus groups command-style prompt families", () => {
     message({ content: "anything uncommitted?", timestamp: "2026-01-01T00:15:00.000Z" }, 16),
     message({ content: "do a code review", timestamp: "2026-01-01T00:16:00.000Z" }, 17),
     message({ content: "review the diff", timestamp: "2026-01-01T00:17:00.000Z" }, 18),
-    message({ content: "inspect the changes", timestamp: "2026-01-01T00:18:00.000Z" }, 19)
+    message({ content: "inspect the changes", timestamp: "2026-01-01T00:18:00.000Z" }, 19),
+    message({ content: "build the app", timestamp: "2026-01-01T00:19:00.000Z" }, 20),
+    message({ content: "relaunch the packaged app", timestamp: "2026-01-01T00:20:00.000Z" }, 21),
+    message({ content: "run the accessibility check", timestamp: "2026-01-01T00:21:00.000Z" }, 22),
+    message({ content: "rerun smoke test", timestamp: "2026-01-01T00:22:00.000Z" }, 23)
   ];
   const corpus = {
     files: messages.map((item) => ({
@@ -267,12 +271,12 @@ test("summarizeParsedCorpus groups command-style prompt families", () => {
   };
 
   const summary = summarizeParsedCorpus(corpus, { project: "sample-app" });
-  assert.equal(summary.totals.userMessages, 19);
-  assert.equal(summary.totals.uniqueUserMessages, 3);
-  assert.equal(summary.messagesByDay[0]?.uniqueCount, 3);
+  assert.equal(summary.totals.userMessages, 23);
+  assert.equal(summary.totals.uniqueUserMessages, 5);
+  assert.equal(summary.messagesByDay[0]?.uniqueCount, 5);
 
   const gitGroup = summary.repeatedUserMessages.find((group) => group.sample === "Git commands");
-  assert.equal(gitGroup?.count, 13);
+  assert.equal(gitGroup?.count, 10);
   assert.deepEqual(
     gitGroup?.variants.map((variant) => variant.sample),
     [
@@ -280,9 +284,6 @@ test("summarizeParsedCorpus groups command-style prompt families", () => {
       "is repo clean?",
       "Have all changes been pushed?",
       "Are all files committed?",
-      "publish to origin",
-      "Deploy to production",
-      "publish",
       "Can you make a commit please",
       "create a new branch",
       "close work tree",
@@ -292,34 +293,72 @@ test("summarizeParsedCorpus groups command-style prompt families", () => {
     ]
   );
 
-  const runAppGroup = summary.repeatedUserMessages.find((group) => group.sample === "Run app");
-  assert.equal(runAppGroup?.count, 3);
+  const deployGroup = summary.repeatedUserMessages.find((group) => group.sample === "Deploy/release");
+  assert.equal(deployGroup?.count, 3);
   assert.deepEqual(
-    runAppGroup?.variants.map((variant) => variant.sample),
-    ["OK open the app for me", "start the server", "run the app"]
+    deployGroup?.variants.map((variant) => variant.sample),
+    ["publish to origin", "Deploy to production", "publish"]
   );
 
-  const codeReviewGroup = summary.repeatedUserMessages.find((group) => group.sample === "Code review");
+  const runAppGroup = summary.repeatedUserMessages.find((group) => group.sample === "Run/build app");
+  assert.equal(runAppGroup?.count, 5);
+  assert.deepEqual(
+    runAppGroup?.variants.map((variant) => variant.sample),
+    [
+      "relaunch the packaged app",
+      "build the app",
+      "OK open the app for me",
+      "start the server",
+      "run the app"
+    ]
+  );
+
+  const codeReviewGroup = summary.repeatedUserMessages.find((group) => group.sample === "Code review/QA");
   assert.equal(codeReviewGroup?.count, 3);
   assert.deepEqual(
     codeReviewGroup?.variants.map((variant) => variant.sample),
     ["inspect the changes", "review the diff", "do a code review"]
   );
 
+  const testingGroup = summary.repeatedUserMessages.find((group) => group.sample === "Testing/verification");
+  assert.equal(testingGroup?.count, 2);
+  assert.deepEqual(
+    testingGroup?.variants.map((variant) => variant.sample),
+    ["rerun smoke test", "run the accessibility check"]
+  );
+
   const search = searchMessages(corpus, { query: "", role: "user", submittedOnly: true });
-  assert.equal(search.results.find((result) => result.content === "do a code review")?.category, "Code review");
+  assert.equal(search.results.find((result) => result.content === "do a code review")?.category, "Code review/QA");
   assert.equal(search.results.find((result) => result.content === "do a code review")?.promptIntent, "Code review/QA");
+  assert.equal(search.results.find((result) => result.content === "publish")?.category, "Deploy/release");
   assert.equal(search.results.find((result) => result.content === "publish")?.promptIntent, "Deploy/release");
+  assert.equal(search.results.find((result) => result.content === "build the app")?.category, "Run/build app");
+  assert.equal(search.results.find((result) => result.content === "run the accessibility check")?.category, "Testing/verification");
 
   const filteredSearch = searchMessages(corpus, {
     query: "",
     role: "user",
     submittedOnly: true,
-    hiddenCategories: ["Code review", "Run app"]
+    hiddenCategories: ["Code review/QA", "Run/build app"]
   });
-  assert.equal(filteredSearch.totalMatches, 13);
-  assert.equal(filteredSearch.results.some((result) => result.category === "Code review"), false);
-  assert.equal(filteredSearch.results.some((result) => result.category === "Run app"), false);
+  assert.equal(filteredSearch.totalMatches, 15);
+  assert.equal(filteredSearch.results.some((result) => result.category === "Code review/QA"), false);
+  assert.equal(filteredSearch.results.some((result) => result.category === "Run/build app"), false);
+
+  const allOperationalFilteredSearch = searchMessages(corpus, {
+    query: "",
+    role: "user",
+    submittedOnly: true,
+    hiddenCategories: [
+      "Code review/QA",
+      "Deploy/release",
+      "Git commands",
+      "Plan approvals",
+      "Run/build app",
+      "Testing/verification"
+    ]
+  });
+  assert.equal(allOperationalFilteredSearch.totalMatches, 0);
 });
 
 test("summarizeParsedCorpus groups short plan approval prompt families", () => {

--- a/scripts/package-macos.mjs
+++ b/scripts/package-macos.mjs
@@ -9,14 +9,15 @@ const repoRoot = resolve(scriptDir, "..");
 const appName = "Codex Log Viewer";
 const executableName = "CodexLogViewerMac";
 const bundleIdentifier = "com.crispierry.codex-log-viewer";
-const appVersion = bumpAppBuildVersion();
-const version = appVersion.marketingVersion;
-const buildVersion = appVersion.bundleVersion;
 const configuration = process.env.CONFIGURATION ?? "release";
 const codeSignIdentity = process.env.CODEX_LOG_VIEWER_CODESIGN_IDENTITY?.trim() || "-";
 const notaryProfile = process.env.CODEX_LOG_VIEWER_NOTARY_PROFILE?.trim();
 const notaryKeychain = process.env.CODEX_LOG_VIEWER_NOTARY_KEYCHAIN?.trim();
 const requireNotarization = process.env.CODEX_LOG_VIEWER_REQUIRE_NOTARIZATION === "1";
+verifyReleaseSigningConfiguration();
+const appVersion = bumpAppBuildVersion();
+const version = appVersion.marketingVersion;
+const buildVersion = appVersion.bundleVersion;
 const buildDir = resolve(repoRoot, "dist/macos");
 const appDir = join(buildDir, `${appName}.app`);
 const contentsDir = join(appDir, "Contents");
@@ -27,7 +28,6 @@ const nodeDir = join(resourcesDir, "node/bin");
 const nodeLibDir = join(resourcesDir, "node/lib");
 let didSignBundle = false;
 
-verifyReleaseSigningConfiguration();
 run("npm", ["run", "build:native-engine"]);
 run("swift", ["build", "--package-path", "apps/macos", "-c", configuration]);
 

--- a/scripts/smoke-native-ui.mjs
+++ b/scripts/smoke-native-ui.mjs
@@ -39,25 +39,38 @@ child.stderr.on("data", (chunk) => {
 });
 
 let windowTextError;
+let waitExitError;
 try {
   await waitForWindowText(["All Projects"], child);
 } catch (error) {
   windowTextError = error;
 }
 
-await waitForExit(child);
+try {
+  await waitForExit(child);
+} catch (error) {
+  waitExitError = error;
+}
+
+await cleanupLaunchedApp();
 assertNoLeakedEngine();
 
 if (child.exitCode !== 0 && child.exitCode !== null) {
-  throw new Error(`Native UI smoke app exited with ${child.exitCode}\n${windowTextError?.message ?? ""}\n${stderr}${stdout}`);
+  throw new Error(
+    `Native UI smoke app exited with ${child.exitCode}\n${windowTextError?.message ?? ""}\n${waitExitError?.message ?? ""}\n${stderr}${stdout}`
+  );
 }
 
 if (child.signalCode !== null) {
-  throw new Error(`Native UI smoke app ended with signal ${child.signalCode}\n${windowTextError?.message ?? ""}\n${stderr}${stdout}`);
+  throw new Error(
+    `Native UI smoke app ended with signal ${child.signalCode}\n${windowTextError?.message ?? ""}\n${waitExitError?.message ?? ""}\n${stderr}${stdout}`
+  );
 }
 
 if (!stdout.includes("Native UI workflow smoke passed.")) {
-  throw new Error(`Native UI workflow did not report success.\n${windowTextError?.message ?? ""}\n${stderr}${stdout}`);
+  throw new Error(
+    `Native UI workflow did not report success.\n${windowTextError?.message ?? ""}\n${waitExitError?.message ?? ""}\n${stderr}${stdout}`
+  );
 }
 
 console.log("Native macOS UI smoke test passed.");
@@ -98,14 +111,64 @@ function waitForExit(process) {
     }
     const timeout = setTimeout(() => {
       requestAppQuit();
-      process.kill("SIGKILL");
       resolvePromise();
-    }, 20_000);
+    }, 90_000);
     process.once("exit", () => {
       clearTimeout(timeout);
       resolvePromise();
     });
   });
+}
+
+async function cleanupLaunchedApp() {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    await waitForProcessesGone(2_000);
+    return;
+  }
+
+  requestAppQuit();
+  if (await waitForProcessesGone(5_000)) {
+    return;
+  }
+
+  child.kill("SIGTERM");
+  if (await waitForProcessesGone(2_000)) {
+    return;
+  }
+
+  killLeakedProcesses();
+  await waitForProcessesGone(2_000);
+}
+
+function waitForProcessesGone(timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  return new Promise((resolvePromise) => {
+    const check = () => {
+      if (leakedProcesses().length === 0) {
+        resolvePromise(true);
+        return;
+      }
+      if (Date.now() >= deadline) {
+        resolvePromise(false);
+        return;
+      }
+      setTimeout(check, 250);
+    };
+    check();
+  });
+}
+
+function killLeakedProcesses() {
+  for (const line of leakedProcesses()) {
+    const pid = Number(line.trim().split(/\s+/, 1)[0]);
+    if (Number.isInteger(pid) && pid > 0) {
+      try {
+        process.kill(pid, "SIGKILL");
+      } catch {
+        // Process may already have exited.
+      }
+    }
+  }
 }
 
 function requestAppQuit() {
@@ -115,13 +178,17 @@ function requestAppQuit() {
   });
 }
 
-function assertNoLeakedEngine() {
+function leakedProcesses() {
   const processList = spawnSync("ps", ["-axo", "pid=,command="], { encoding: "utf8" }).stdout;
   const bundledEnginePath = `${appPath}/Contents/Resources/engine/apps/server/dist/index.js`;
-  const leaks = processList
+  return processList
     .split("\n")
     .filter((line) => line.includes(bundledEnginePath) || line.includes(executablePath))
     .filter((line) => !line.includes("ps -axo"));
+}
+
+function assertNoLeakedEngine() {
+  const leaks = leakedProcesses();
 
   if (leaks.length > 0) {
     throw new Error(`Native UI smoke left app or engine processes running:\n${leaks.join("\n")}`);


### PR DESCRIPTION
## Summary

This PR prepares Codex Log Viewer for opening the repository publicly and fixes the native app regressions found during the final pass.

It updates the public-readiness docs, fixture docs, CLI help, packaging validation, and local-only ignore rules. It also aligns operational message filtering with the newer Project Focus taxonomy so `View > Operational Messages > All` restores all in-scope messages, updates saved-filter migration, and keeps menu checkmarks responsive.

The native app fixes include scoping session inspector messages to the selected daily session slice, keeping `View > Show Sessions` enabled after the sessions column is displayed, and making Search's `Show Conversation` navigate the whole Browse scene consistently: project scope, highlighted user-message row, scroll position, and right-hand conversation detail now point to the same conversation.

## Validation

- `wt bootstrap`
- `npm run privacy:scan`
- `npm run lint`
- `npm test`
- `npm run check:mac-accessibility`
- `npm audit --audit-level=moderate`
- local Markdown link-resolution check
- `npm run benchmark:search`
- `npm run check:reference -- --reference fixtures/codex/sample-reference-summary.json --path fixtures/codex/sample-session.jsonl --project sample-app`
- `git diff --check`
- `npm run package:mac`
- `npm run smoke:mac-package`
- `npm run smoke:mac-ui`
- `npm run release:notes -- --tag v0.1.0 --output dist/macos/release-notes.md`
- packaged archive checksum verification
- live menu probe for `View > Show Sessions`

## Notes

The packaged macOS app was rebuilt and relaunched locally as build 96. Separate local article-draft files are intentionally not included in this PR.
