### PR TITLE
[codex] Fix parser file discovery concurrency

### DIFF
--- a/app-version.json
+++ b/app-version.json
@@ -1,5 +1,5 @@
 {
   "major": 0,
   "minor": 1,
-  "build": 122
+  "build": 123
 }

--- a/apps/macos/Sources/CodexLogViewerMac/AppVersion.swift
+++ b/apps/macos/Sources/CodexLogViewerMac/AppVersion.swift
@@ -4,8 +4,8 @@
 enum AppVersion {
   static let major = 0
   static let minor = 1
-  static let build = 122
+  static let build = 123
   static let marketingVersion = "0.1"
-  static let bundleVersion = "122"
-  static let displayVersion = "0.1 (Build 122)"
+  static let bundleVersion = "123"
+  static let displayVersion = "0.1 (Build 123)"
 }

--- a/docs/ai-worklog.md
+++ b/docs/ai-worklog.md
@@ -2,6 +2,45 @@
 
 Sanitized audit trail of AI-assisted work on this project.
 
+## 2026-05-31 - Limit Parser File Discovery Concurrency
+
+Status: Completed
+Related commit/PR: TBD
+
+### User Messages
+
+> I'm getting this error from our app. What does it mean? How do we fix it?
+>
+> The local parser engine returned HTTP 500 for api/projects: {"error":"EMFILE: too many open files, scandir '[local Codex sessions path]'"}
+
+### Interpreted Intent
+
+The user wanted the local parser engine error explained and fixed so large local Codex session histories do not crash project loading.
+
+### Response / Work Done
+
+- Identified the root cause as unbounded parallel directory traversal in Codex log discovery.
+- Replaced recursive `Promise.all` scanning with an iterative, controlled directory walk that avoids opening many directories at once.
+- Added a small concurrency helper and capped parser file work for no-cache corpus parsing and metadata fingerprinting.
+- Added a fixture-driven discovery test that covers nested session paths, wide directory trees, sorted output, and ignored `.git` / `node_modules` directories.
+- Packaged and relaunched the native macOS app at build 123 for review.
+
+### Privacy Notes
+
+No raw Codex logs, private prompts, screenshots, session content, export payloads, credentials, or secrets were added. The reported local sessions path was redacted in this worklog.
+
+### Verification
+
+- Ran `wt bootstrap`.
+- Ran `npm run test -w @codex-log-viewer/parser`.
+- Ran `npm test`.
+- Ran `npm run lint`.
+- Ran `npm run package:mac`.
+- Ran `npm run smoke:mac-package`.
+- Ran `npm run privacy:scan`.
+- Ran `git diff --check`.
+- Relaunched `dist/macos/Codex Log Viewer.app`.
+
 ## 2026-05-29 - Merge Main Evals And Extend Performance Work
 
 Status: Completed

--- a/packages/parser/src/cache.ts
+++ b/packages/parser/src/cache.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import { mkdir, readFile, realpath, rm, stat, writeFile } from "node:fs/promises";
 import { isAbsolute, relative, resolve } from "node:path";
+import { mapWithConcurrency } from "./concurrency.js";
 import { defaultCodexLogRoots, discoverCodexLogFiles } from "./discover.js";
 import { parseCodexLogFile } from "./parser.js";
 import type {
@@ -13,6 +14,8 @@ import type {
 
 const CACHE_SCHEMA_VERSION = 1;
 const PARSER_CACHE_VERSION = "parser-v5";
+const FILE_METADATA_CONCURRENCY = 32;
+const PARSE_FILE_CONCURRENCY = 16;
 
 interface CacheManifest {
   schemaVersion: number;
@@ -46,7 +49,7 @@ interface SourceScope {
 export async function parseCodexCorpusWithCache(options: ParseOptions = {}): Promise<CachedParsedCodexCorpus> {
   if (!options.cacheDir) {
     const files = await discoverCodexLogFiles(options.paths);
-    const parsedFiles = await Promise.all(files.map((file) => parseCodexLogFile(file)));
+    const parsedFiles = await mapWithConcurrency(files, PARSE_FILE_CONCURRENCY, (file) => parseCodexLogFile(file));
     return {
       corpus: corpusFromParsedFiles(parsedFiles),
       cache: cacheMetadata("updated", 0, parsedFiles.length, 0, parsedFiles.length)
@@ -58,7 +61,9 @@ export async function parseCodexCorpusWithCache(options: ParseOptions = {}): Pro
   await mkdir(filesDirectory, { recursive: true });
 
   const discoveredFiles = await canonicalLogFiles(await discoverCodexLogFiles(options.paths));
-  const fingerprints = await Promise.all(discoveredFiles.map((filePath) => fingerprintFor(filePath)));
+  const fingerprints = await mapWithConcurrency(discoveredFiles, FILE_METADATA_CONCURRENCY, (filePath) =>
+    fingerprintFor(filePath)
+  );
   const activeKeys = new Set(fingerprints.map((fingerprint) => fingerprint.cacheKey));
   const sourceScopes = await scopesFor(options.paths ?? defaultCodexLogRoots());
   const manifest = await readManifest(cacheDirectory);
@@ -186,11 +191,12 @@ async function removeCachedFile(filesDirectory: string, cacheFile: string): Prom
 
 async function canonicalLogFiles(files: string[]): Promise<string[]> {
   const canonical = new Set<string>();
-  await Promise.all(
-    files.map(async (filePath) => {
-      canonical.add(await canonicalPath(filePath));
-    })
+  const canonicalPaths = await mapWithConcurrency(files, FILE_METADATA_CONCURRENCY, (filePath) =>
+    canonicalPath(filePath)
   );
+  for (const filePath of canonicalPaths) {
+    canonical.add(filePath);
+  }
   return [...canonical].sort();
 }
 

--- a/packages/parser/src/concurrency.ts
+++ b/packages/parser/src/concurrency.ts
@@ -1,0 +1,20 @@
+export async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  concurrency: number,
+  mapper: (item: T, index: number) => Promise<R>
+): Promise<R[]> {
+  const workerCount = Math.min(items.length, Math.max(1, Math.floor(concurrency)));
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+
+  async function worker(): Promise<void> {
+    while (nextIndex < items.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      results[index] = await mapper(items[index] as T, index);
+    }
+  }
+
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+  return results;
+}

--- a/packages/parser/src/discover.ts
+++ b/packages/parser/src/discover.ts
@@ -2,6 +2,8 @@ import { readdir, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 
+const IGNORED_DIRECTORIES = new Set(["node_modules", ".git"]);
+
 export function defaultCodexLogRoots(homeDir = homedir()): string[] {
   return [
     join(homeDir, ".codex", "sessions"),
@@ -19,33 +21,46 @@ export async function discoverCodexLogFiles(paths = defaultCodexLogRoots()): Pro
   return [...files].sort();
 }
 
-async function collectJsonlFiles(path: string, files: Set<string>): Promise<void> {
-  let info;
-  try {
-    info = await stat(path);
-  } catch {
-    return;
-  }
+async function collectJsonlFiles(rootPath: string, files: Set<string>): Promise<void> {
+  const pending = [rootPath];
 
-  if (info.isFile()) {
-    if (path.endsWith(".jsonl")) {
-      files.add(path);
+  while (pending.length > 0) {
+    const currentPath = pending.pop() as string;
+    let info;
+    try {
+      info = await stat(currentPath);
+    } catch {
+      continue;
     }
-    return;
-  }
 
-  if (!info.isDirectory()) {
-    return;
-  }
-
-  const entries = await readdir(path, { withFileTypes: true });
-  await Promise.all(
-    entries.map(async (entry) => {
-      if (entry.name === "node_modules" || entry.name === ".git") {
-        return;
+    if (info.isFile()) {
+      if (currentPath.endsWith(".jsonl")) {
+        files.add(currentPath);
       }
-      await collectJsonlFiles(join(path, entry.name), files);
-    })
-  );
-}
+      continue;
+    }
 
+    if (!info.isDirectory()) {
+      continue;
+    }
+
+    let entries;
+    try {
+      entries = await readdir(currentPath, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      if (IGNORED_DIRECTORIES.has(entry.name)) {
+        continue;
+      }
+      const entryPath = join(currentPath, entry.name);
+      if (entry.isFile() && entryPath.endsWith(".jsonl")) {
+        files.add(entryPath);
+      } else if (entry.isDirectory() || entry.isSymbolicLink()) {
+        pending.push(entryPath);
+      }
+    }
+  }
+}

--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -1,6 +1,7 @@
 import { createReadStream } from "node:fs";
 import { basename } from "node:path";
 import { createInterface } from "node:readline";
+import { mapWithConcurrency } from "./concurrency.js";
 import { discoverCodexLogFiles } from "./discover.js";
 import type {
   JsonObject,
@@ -17,6 +18,8 @@ import type {
   TurnRecord,
   UnknownEventRecord
 } from "./types.js";
+
+const PARSE_FILE_CONCURRENCY = 16;
 
 interface ParseState {
   sessionId: string;
@@ -52,7 +55,7 @@ const USER_REQUEST_MARKER = "## My request for Codex:";
 
 export async function parseCodexCorpus(options: ParseOptions = {}): Promise<ParsedCodexCorpus> {
   const files = await discoverCodexLogFiles(options.paths);
-  const parsedFiles = await Promise.all(files.map((file) => parseCodexLogFile(file)));
+  const parsedFiles = await mapWithConcurrency(files, PARSE_FILE_CONCURRENCY, (file) => parseCodexLogFile(file));
 
   return {
     files: parsedFiles,

--- a/packages/parser/test/discover.test.mjs
+++ b/packages/parser/test/discover.test.mjs
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { tmpdir } from "node:os";
+import test from "node:test";
+import { discoverCodexLogFiles } from "../dist/index.js";
+
+test("discoverCodexLogFiles finds nested jsonl logs without including ignored directories", async () => {
+  const tempDir = await mkdtemp(`${tmpdir()}/codex-log-viewer-discover-`);
+  const sessionsDir = join(tempDir, "sessions");
+  const firstSession = join(sessionsDir, "2026", "05", "31", "rollout-first.jsonl");
+  const secondSession = join(sessionsDir, "2026", "05", "30", "rollout-second.jsonl");
+  const ignoredGitSession = join(sessionsDir, ".git", "rollout-ignored.jsonl");
+  const ignoredNodeSession = join(sessionsDir, "node_modules", "rollout-ignored.jsonl");
+
+  try {
+    await writeFixture(firstSession);
+    await writeFixture(secondSession);
+    await writeFixture(ignoredGitSession);
+    await writeFixture(ignoredNodeSession);
+    await writeFile(join(sessionsDir, "notes.txt"), "not a log\n", "utf8");
+
+    for (let index = 0; index < 160; index += 1) {
+      await writeFixture(join(sessionsDir, "wide", String(index), `rollout-${index}.jsonl`));
+    }
+
+    const files = await discoverCodexLogFiles([sessionsDir]);
+
+    assert.equal(files.includes(firstSession), true);
+    assert.equal(files.includes(secondSession), true);
+    assert.equal(files.some((file) => file.includes(".git")), false);
+    assert.equal(files.some((file) => file.includes("node_modules")), false);
+    assert.equal(files.length, 162);
+    assert.deepEqual(files, [...files].sort());
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+async function writeFixture(filePath) {
+  await mkdir(dirname(filePath), { recursive: true });
+  await writeFile(filePath, "{}\n", "utf8");
+}


### PR DESCRIPTION
## Summary

Fixes the local parser engine crash that could appear as `EMFILE: too many open files` while loading `/api/projects` for large Codex session histories.

## What changed

- Replaced unbounded recursive directory scanning with an iterative log discovery walk.
- Added a bounded concurrency helper and used it for parser file work and cache metadata fingerprinting.
- Added regression coverage for nested and wide log directory trees, sorted output, and ignored `.git` / `node_modules` directories.
- Updated the AI worklog and bumped the packaged macOS app build to 123 after rebuilding and relaunching.

## Why

The previous scanner used recursive `Promise.all` traversal, which could ask macOS to scan too many directories at once. On larger local Codex histories, that could exhaust the process file descriptor limit and make the local API return HTTP 500.

## Validation

- `wt bootstrap`
- `npm run test -w @codex-log-viewer/parser`
- `npm test`
- `npm run lint`
- `npm run package:mac`
- `npm run smoke:mac-package`
- `npm run privacy:scan`
- `git diff --check`
- Relaunched `dist/macos/Codex Log Viewer.app`
