### PR TITLE
[codex] Fix large cache parsing and align web demo UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This project has a working v0 implementation:
 - CLI summaries and exports
 - Private local API engine for the app
 - Native SwiftUI macOS app
+- Static synthetic web demo for project showcases
 - Cross-project message search
 - Sanitized fixtures and tests
 - GitHub Actions CI
@@ -50,6 +51,12 @@ npm run package:mac
 open "dist/macos/Codex Log Viewer.app"
 ```
 
+To run the static synthetic web demo:
+
+```sh
+npm run dev:web-demo
+```
+
 ## macOS App
 
 The app is the primary product experience. From the desktop UI you can:
@@ -79,6 +86,16 @@ npm run app:mac
 The macOS app is native SwiftUI. It reuses the local parser, analytics, and private API engine so parsing stays fixture-driven and local.
 
 Packaged releases bundle the local engine and a known Node runtime so end users do not need to run a terminal setup. Source builds still require Node and Swift tooling.
+
+## Web Demo
+
+The web demo is a standalone static showcase built from generated synthetic Codex JSONL profiles. It mirrors the primary product workflows with project metrics, Browse, Search, Audit preview, and synthetic JSON/CSV exports, while linking users to the GitHub repository and macOS releases for the real app.
+
+It does not upload, ingest, or parse real user logs in the browser. Build it with:
+
+```sh
+npm run build:web-demo
+```
 
 ## CLI
 
@@ -125,6 +142,8 @@ npm run smoke:mac-ui # macOS only
 npm run release:mac # macOS only, package plus smoke tests
 npm run benchmark:search
 npm run check:reference -- --reference fixtures/codex/sample-reference-summary.json --path fixtures/codex/sample-session.jsonl --project sample-app
+npm run check:web-demo-data
+npm run build:web-demo
 ```
 
 ## Documentation
@@ -145,6 +164,7 @@ npm run check:reference -- --reference fixtures/codex/sample-reference-summary.j
 - [Milestones](docs/milestones.md)
 - [Usage](docs/usage.md)
 - [UI test plan](docs/ui-test-plan.md)
+- [Static web demo](docs/web-demo.md)
 
 ## Development Principles
 

--- a/app-version.json
+++ b/app-version.json
@@ -1,5 +1,5 @@
 {
   "major": 0,
   "minor": 2,
-  "patch": 8
+  "patch": 9
 }

--- a/app-version.json
+++ b/app-version.json
@@ -1,5 +1,5 @@
 {
   "major": 0,
-  "minor": 2,
-  "patch": 9
+  "minor": 3,
+  "patch": 0
 }

--- a/apps/macos/Sources/CodexLogViewerMac/AppVersion.swift
+++ b/apps/macos/Sources/CodexLogViewerMac/AppVersion.swift
@@ -4,8 +4,8 @@
 enum AppVersion {
   static let major = 0
   static let minor = 2
-  static let patch = 8
-  static let marketingVersion = "0.2.8"
-  static let bundleVersion = "0.2.8"
-  static let displayVersion = "0.2.8"
+  static let patch = 9
+  static let marketingVersion = "0.2.9"
+  static let bundleVersion = "0.2.9"
+  static let displayVersion = "0.2.9"
 }

--- a/apps/macos/Sources/CodexLogViewerMac/AppVersion.swift
+++ b/apps/macos/Sources/CodexLogViewerMac/AppVersion.swift
@@ -3,9 +3,9 @@
 
 enum AppVersion {
   static let major = 0
-  static let minor = 2
-  static let patch = 9
-  static let marketingVersion = "0.2.9"
-  static let bundleVersion = "0.2.9"
-  static let displayVersion = "0.2.9"
+  static let minor = 3
+  static let patch = 0
+  static let marketingVersion = "0.3.0"
+  static let bundleVersion = "0.3.0"
+  static let displayVersion = "0.3.0"
 }

--- a/apps/web-demo/index.html
+++ b/apps/web-demo/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Synthetic static web demo for the local-first Codex Log Viewer macOS app."
+    />
+    <title>Codex Log Viewer Demo</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/web-demo/package.json
+++ b/apps/web-demo/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@codex-log-viewer/web-demo",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Static synthetic web demo for Codex Log Viewer.",
+  "type": "module",
+  "scripts": {
+    "generate:data": "node ../../scripts/generate-web-demo-data.mjs",
+    "pregenerate:data": "npm run build -w @codex-log-viewer/parser && npm run build -w @codex-log-viewer/analytics",
+    "dev": "npm run generate:data && vite --host 127.0.0.1 --port 5174",
+    "build": "npm run generate:data && vite build",
+    "preview": "vite preview --host 127.0.0.1 --port 4174",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.2",
+    "vite": "^8.0.16"
+  },
+  "dependencies": {
+    "lucide-react": "^1.17.0",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7"
+  }
+}

--- a/apps/web-demo/public/app-icon.svg
+++ b/apps/web-demo/public/app-icon.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024">
+  <defs>
+    <linearGradient id="bg" x1="120" y1="120" x2="904" y2="904" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#1d4ed8"/>
+      <stop offset="0.55" stop-color="#0f766e"/>
+      <stop offset="1" stop-color="#111827"/>
+    </linearGradient>
+  </defs>
+  <rect x="64" y="64" width="896" height="896" rx="192" fill="url(#bg)"/>
+  <rect x="202" y="236" width="620" height="552" rx="48" fill="#f8fafc" opacity="0.96"/>
+  <rect x="262" y="318" width="304" height="36" rx="18" fill="#111827"/>
+  <rect x="262" y="408" width="500" height="32" rx="16" fill="#334155"/>
+  <rect x="262" y="490" width="420" height="32" rx="16" fill="#334155"/>
+  <rect x="262" y="572" width="330" height="32" rx="16" fill="#334155"/>
+  <circle cx="690" cy="670" r="86" fill="none" stroke="#0f766e" stroke-width="44"/>
+  <path d="M748 728L830 810" stroke="#0f766e" stroke-width="50" stroke-linecap="round"/>
+</svg>

--- a/apps/web-demo/src/App.tsx
+++ b/apps/web-demo/src/App.tsx
@@ -1,0 +1,719 @@
+import type { CSSProperties, ReactNode } from "react";
+import { useEffect, useMemo, useState } from "react";
+import {
+  Activity,
+  BarChart3,
+  Code2,
+  Download,
+  ExternalLink,
+  FileText,
+  ListTree,
+  Search,
+  ShieldCheck,
+  Terminal,
+  Wrench
+} from "lucide-react";
+import demoDataRaw from "./data/demo-data.generated.json";
+import type {
+  DemoData,
+  DemoInteraction,
+  MessageRole,
+  MessageSearchResult,
+  ProjectSummary,
+  SessionDetail,
+  TokenUsage
+} from "./types";
+
+type Section = "overview" | "browse" | "search" | "audit";
+type SearchRole = MessageRole | "all";
+
+interface BrowseInteraction extends DemoInteraction {
+  project: string;
+  cwd?: string;
+  sessionFirstSeen?: string;
+}
+
+const demoData = demoDataRaw as DemoData;
+const allProjectsName = "All Projects";
+const sections: Array<{ id: Section; label: string; icon: typeof BarChart3 }> = [
+  { id: "overview", label: "Overview", icon: BarChart3 },
+  { id: "browse", label: "Browse", icon: ListTree },
+  { id: "search", label: "Search", icon: Search },
+  { id: "audit", label: "Audit", icon: FileText }
+];
+
+export default function App() {
+  const [selectedProject, setSelectedProject] = useState(allProjectsName);
+  const [selectedSection, setSelectedSection] = useState<Section>("overview");
+  const [selectedInteractionId, setSelectedInteractionId] = useState<string>();
+  const [query, setQuery] = useState("");
+  const [role, setRole] = useState<SearchRole>("all");
+  const [selectedSearchId, setSelectedSearchId] = useState<string>();
+
+  const summary = demoData.summaries[selectedProject] ?? demoData.summaries[allProjectsName];
+  const browseInteractions = useMemo(
+    () => interactionsForProject(demoData.sessionDetails, selectedProject),
+    [selectedProject]
+  );
+  const selectedInteraction = browseInteractions.find((item) => item.id === selectedInteractionId) ??
+    browseInteractions[0];
+  const searchResults = useMemo(
+    () => searchMessages(demoData.messages, selectedProject, query, role),
+    [selectedProject, query, role]
+  );
+  const selectedSearchResult = searchResults.find((item) => item.id === selectedSearchId) ?? searchResults[0];
+  const selectedTabId = `section-tab-${selectedSection}`;
+
+  useEffect(() => {
+    if (!selectedInteraction || selectedInteraction.id === selectedInteractionId) {
+      return;
+    }
+    setSelectedInteractionId(selectedInteraction.id);
+  }, [selectedInteraction, selectedInteractionId]);
+
+  useEffect(() => {
+    if (!selectedSearchResult || selectedSearchResult.id === selectedSearchId) {
+      return;
+    }
+    setSelectedSearchId(selectedSearchResult.id);
+  }, [selectedSearchId, selectedSearchResult]);
+
+  return (
+    <div className="site-page">
+      <SiteHeader />
+
+      <div className="app-shell">
+        <aside className="sidebar">
+          <div className="brand">
+            <img src="./app-icon.svg" alt="" />
+            <div>
+              <strong>Codex Log Viewer</strong>
+              <span>Static synthetic demo</span>
+            </div>
+          </div>
+
+          <nav className="project-nav" aria-label="Projects">
+            <ProjectButton
+              active={selectedProject === allProjectsName}
+              label={allProjectsName}
+              meta={`${demoData.summaries[allProjectsName].totals.sessions} sessions`}
+              onClick={() => setSelectedProject(allProjectsName)}
+            />
+            {demoData.projects.map((project) => (
+              <ProjectButton
+                key={project.project}
+                active={selectedProject === project.project}
+                label={project.project}
+                meta={`${project.messages} prompts`}
+                onClick={() => setSelectedProject(project.project)}
+              />
+            ))}
+          </nav>
+
+          <div className="sidebar-footer">
+            <div className="source-pill">
+              <ShieldCheck size={16} aria-hidden="true" />
+              <span>Generated synthetic data</span>
+            </div>
+            <a className="link-button" href={demoData.links.repository} target="_blank" rel="noreferrer">
+              <Code2 size={17} aria-hidden="true" />
+              <span>Repository</span>
+              <ExternalLink size={14} aria-hidden="true" />
+            </a>
+            <a className="link-button" href={demoData.links.releases} target="_blank" rel="noreferrer">
+              <Download size={17} aria-hidden="true" />
+              <span>Download app</span>
+              <ExternalLink size={14} aria-hidden="true" />
+            </a>
+          </div>
+        </aside>
+
+        <main className="workspace">
+          <header className="workspace-header">
+            <div className="workspace-title">
+              <h1>{summary.project}</h1>
+              <p>{activityRange(summary)} · {demoData.source.fixturePath}</p>
+            </div>
+
+            <div className="section-tabs" role="tablist" aria-label="Sections">
+              {sections.map((section) => {
+                const Icon = section.icon;
+                return (
+                  <button
+                    key={section.id}
+                    className={section.id === selectedSection ? "active" : ""}
+                    id={`section-tab-${section.id}`}
+                    role="tab"
+                    aria-controls="section-panel"
+                    aria-selected={section.id === selectedSection}
+                    type="button"
+                    onClick={() => setSelectedSection(section.id)}
+                  >
+                    <Icon size={16} aria-hidden="true" />
+                    {section.label}
+                  </button>
+                );
+              })}
+            </div>
+          </header>
+
+          <div id="section-panel" role="tabpanel" aria-labelledby={selectedTabId}>
+            {selectedSection === "overview" && <Overview summary={summary} />}
+            {selectedSection === "browse" && (
+              <Browse
+                interactions={browseInteractions}
+                selectedInteraction={selectedInteraction}
+                onSelect={setSelectedInteractionId}
+              />
+            )}
+            {selectedSection === "search" && (
+              <SearchSection
+                query={query}
+                role={role}
+                results={searchResults}
+                selectedResult={selectedSearchResult}
+                onQueryChange={setQuery}
+                onRoleChange={setRole}
+                onSelect={setSelectedSearchId}
+              />
+            )}
+            {selectedSection === "audit" && <Audit summary={summary} />}
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+}
+
+function SiteHeader() {
+  const links = [
+    { label: "Ask Me Anything", href: "/ask" },
+    { label: "Writing", href: "/writing" },
+    { label: "Notes", href: "/posts" },
+    { label: "Projects", href: "/projects" },
+    { label: "Photography", href: "/photography" }
+  ];
+
+  return (
+    <header className="site-header">
+      <div className="site-top-bar" />
+      <div className="site-nav">
+        <a className="site-brand" href="/">
+          <span className="site-logo-mark" aria-hidden="true" />
+          <span>Cristiano Pierry</span>
+        </a>
+        <nav className="site-links" aria-label="Personal website">
+          {links.map((link) => (
+            <a key={link.href} href={link.href}>
+              {link.label}
+            </a>
+          ))}
+        </nav>
+      </div>
+      <div className="site-network-band" aria-hidden="true">
+        <span className="network-node node-a" />
+        <span className="network-node node-b" />
+        <span className="network-node node-c" />
+        <span className="network-node node-d" />
+      </div>
+    </header>
+  );
+}
+
+function ProjectButton(props: {
+  active: boolean;
+  label: string;
+  meta: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      className={props.active ? "project-button active" : "project-button"}
+      type="button"
+      aria-pressed={props.active}
+      onClick={props.onClick}
+    >
+      <span>{props.label}</span>
+      <small>{props.meta}</small>
+    </button>
+  );
+}
+
+function Overview({ summary }: { summary: ProjectSummary }) {
+  const maxDailyMessages = Math.max(...summary.messagesByDay.map((bucket) => bucket.count), 1);
+  const maxIntentCount = Math.max(...summary.promptIntents.buckets.map((bucket) => bucket.count), 1);
+  const maxModelTokens = Math.max(...summary.models.map((model) => model.tokens.totalTokens), 1);
+
+  return (
+    <section className="section-stack">
+      <div className="metrics-grid">
+        <Metric icon={<Activity size={18} />} label="Sessions" value={formatNumber(summary.totals.sessions)} />
+        <Metric icon={<ListTree size={18} />} label="User prompts" value={formatNumber(summary.totals.userMessages)} />
+        <Metric icon={<BarChart3 size={18} />} label="Total tokens" value={formatCompact(summary.tokens.totalTokens)} />
+        <Metric icon={<Search size={18} />} label="Unique prompts" value={formatNumber(summary.totals.uniqueUserMessages)} />
+        <Metric icon={<Wrench size={18} />} label="Tool events" value={formatNumber(summary.totals.toolEvents)} />
+        <Metric icon={<Terminal size={18} />} label="Warnings" value={formatNumber(summary.totals.parseWarnings)} tone="warn" />
+      </div>
+
+      <div className="overview-grid">
+        <Panel title="Activity By Day">
+          <div className="bar-list">
+            {summary.messagesByDay.map((bucket) => (
+              <BarRow
+                key={bucket.key}
+                label={shortDate(bucket.key)}
+                value={`${bucket.count} prompts`}
+                width={(bucket.count / maxDailyMessages) * 100}
+                tone="teal"
+              />
+            ))}
+          </div>
+        </Panel>
+
+        <Panel title="Model Usage">
+          <div className="bar-list">
+            {summary.models.map((model) => (
+              <BarRow
+                key={model.model}
+                label={model.model}
+                value={`${formatCompact(model.tokens.totalTokens)} tokens`}
+                width={(model.tokens.totalTokens / maxModelTokens) * 100}
+                tone="blue"
+              />
+            ))}
+          </div>
+        </Panel>
+
+        <Panel title="Project Focus">
+          <div className="bar-list">
+            {summary.promptIntents.buckets.slice(0, 7).map((bucket) => (
+              <BarRow
+                key={bucket.key}
+                label={bucket.label}
+                value={`${bucket.count} · ${bucket.percentage}%`}
+                width={(bucket.count / maxIntentCount) * 100}
+                tone="gold"
+              />
+            ))}
+          </div>
+        </Panel>
+
+        <Panel title="Repeated Prompts">
+          <div className="repeat-list">
+            {summary.repeatedUserMessages.length > 0 ? summary.repeatedUserMessages.map((item) => (
+              <div className="repeat-row" key={item.id}>
+                <strong>{item.sample}</strong>
+                <span>{item.count} uses across {item.sessionCount} sessions</span>
+              </div>
+            )) : (
+              <EmptyState>No repeated prompts in this project slice.</EmptyState>
+            )}
+          </div>
+        </Panel>
+      </div>
+    </section>
+  );
+}
+
+function Browse(props: {
+  interactions: BrowseInteraction[];
+  selectedInteraction?: BrowseInteraction;
+  onSelect: (id: string) => void;
+}) {
+  return (
+    <section className="browser-grid">
+      <div className="list-panel">
+        <div className="panel-heading">
+          <h2>Submitted Prompts</h2>
+          <span>{props.interactions.length}</span>
+        </div>
+        <div className="prompt-list">
+          {props.interactions.map((interaction) => (
+            <button
+              key={interaction.id}
+              className={interaction.id === props.selectedInteraction?.id ? "prompt-row active" : "prompt-row"}
+              type="button"
+              onClick={() => props.onSelect(interaction.id)}
+            >
+              <strong>{interaction.userMessage}</strong>
+              <span>{interaction.project} · {formatDateTime(interaction.timestamp)}</span>
+              <small>{interaction.promptIntent}</small>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="detail-panel">
+        {props.selectedInteraction ? <InteractionDetail interaction={props.selectedInteraction} /> : (
+          <EmptyState>No submitted prompts are available for this project.</EmptyState>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function InteractionDetail({ interaction }: { interaction: BrowseInteraction }) {
+  return (
+    <div className="interaction-detail">
+      <div className="detail-title">
+        <div>
+          <p>{interaction.project}</p>
+          <h2>{interaction.userMessage}</h2>
+        </div>
+        <span className="intent-badge">{interaction.promptIntent}</span>
+      </div>
+
+      <div className="detail-meta">
+        <span>{interaction.model}</span>
+        <span>{interaction.effort ?? "default"} effort</span>
+        <span>{formatDuration(interaction.durationMs)}</span>
+        <span>{formatDateTime(interaction.timestamp)}</span>
+      </div>
+
+      <div className="response-block">
+        <h3>Codex Response</h3>
+        <p>{interaction.assistantMessage}</p>
+      </div>
+
+      {interaction.contextMessages.length > 0 && (
+        <div className="response-block subdued">
+          <h3>Context</h3>
+          {interaction.contextMessages.map((message) => <p key={message}>{message}</p>)}
+        </div>
+      )}
+
+      <div className="detail-columns">
+        <Panel title="Token Use">
+          <TokenStack usage={interaction.tokenUsage} />
+        </Panel>
+        <Panel title="Tool Activity">
+          <div className="tool-list">
+            {interaction.tools.length > 0 ? interaction.tools.map((tool, index) => (
+              <div className="tool-row" key={`${tool.eventType}-${tool.callId ?? index}`}>
+                <Wrench size={15} aria-hidden="true" />
+                <div>
+                  <strong>{tool.name ?? tool.eventType}</strong>
+                  <span>{tool.content ?? tool.cwd ?? "Completed"}</span>
+                </div>
+              </div>
+            )) : <EmptyState>No tool calls recorded.</EmptyState>}
+          </div>
+        </Panel>
+      </div>
+    </div>
+  );
+}
+
+function SearchSection(props: {
+  query: string;
+  role: SearchRole;
+  results: MessageSearchResult[];
+  selectedResult?: MessageSearchResult;
+  onQueryChange: (value: string) => void;
+  onRoleChange: (value: SearchRole) => void;
+  onSelect: (id: string) => void;
+}) {
+  return (
+    <section className="search-layout">
+      <div className="search-toolbar">
+        <label className="search-input">
+          <Search size={17} aria-hidden="true" />
+          <input
+            value={props.query}
+            onChange={(event) => props.onQueryChange(event.target.value)}
+            aria-label="Search messages"
+            placeholder="Search synthetic messages"
+          />
+        </label>
+        <select
+          value={props.role}
+          aria-label="Message role"
+          onChange={(event) => props.onRoleChange(event.target.value as SearchRole)}
+        >
+          <option value="all">All roles</option>
+          <option value="user">User</option>
+          <option value="assistant">Assistant</option>
+          <option value="developer">Developer</option>
+        </select>
+        <span className="result-count">{props.results.length} matches</span>
+      </div>
+
+      <div className="search-grid">
+        <div className="search-results">
+          {props.results.map((result) => (
+            <button
+              key={result.id}
+              className={result.id === props.selectedResult?.id ? "search-row active" : "search-row"}
+              type="button"
+              onClick={() => props.onSelect(result.id)}
+            >
+              <span>{result.role}</span>
+              <strong>{result.snippet}</strong>
+              <small>{result.project} · {formatDateTime(result.timestamp)}</small>
+            </button>
+          ))}
+        </div>
+
+        <div className="message-detail">
+          {props.selectedResult ? (
+            <>
+              <div className="detail-title compact">
+                <div>
+                  <p>{props.selectedResult.role}</p>
+                  <h2>{props.selectedResult.project}</h2>
+                </div>
+                {props.selectedResult.promptIntent && <span className="intent-badge">{props.selectedResult.promptIntent}</span>}
+              </div>
+              <pre>{props.selectedResult.content.trim()}</pre>
+              <div className="detail-meta">
+                <span>{props.selectedResult.model ?? "unknown model"}</span>
+                <span>{props.selectedResult.sourceEvent}</span>
+                <span>{props.selectedResult.sessionId}</span>
+              </div>
+            </>
+          ) : <EmptyState>No matching messages.</EmptyState>}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function Audit({ summary }: { summary: ProjectSummary }) {
+  return (
+    <section className="audit-grid">
+      <div className="audit-main">
+        <div className="panel-heading">
+          <h2>AI Worklog Preview</h2>
+          <span>{demoData.auditPreview.appendedSections} new sections</span>
+        </div>
+        <pre className="markdown-preview">{demoData.auditPreview.generatedMarkdown}</pre>
+      </div>
+
+      <aside className="export-panel">
+        <Panel title="Export Preview">
+          <div className="export-actions">
+            <button type="button" onClick={() => downloadSummaryJson(summary)}>
+              <Download size={17} aria-hidden="true" />
+              JSON
+            </button>
+            <button type="button" onClick={() => downloadSummaryCsv(summary)}>
+              <Download size={17} aria-hidden="true" />
+              CSV
+            </button>
+          </div>
+          <div className="export-facts">
+            <span>Target</span>
+            <strong>{demoData.auditPreview.targetPath}</strong>
+            <span>Privacy</span>
+            <strong>Public synthetic mode</strong>
+            <span>Generated</span>
+            <strong>{formatDateTime(demoData.generatedAt)}</strong>
+          </div>
+        </Panel>
+
+        <Panel title="Current Summary">
+          <TokenStack usage={summary.tokens} />
+        </Panel>
+      </aside>
+    </section>
+  );
+}
+
+function Metric(props: { icon: ReactNode; label: string; value: string; tone?: "warn" }) {
+  return (
+    <div className={props.tone === "warn" ? "metric warn" : "metric"}>
+      <span>{props.icon}</span>
+      <div>
+        <strong>{props.value}</strong>
+        <small>{props.label}</small>
+      </div>
+    </div>
+  );
+}
+
+function Panel({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <section className="panel">
+      <h2>{title}</h2>
+      {children}
+    </section>
+  );
+}
+
+function BarRow(props: {
+  label: string;
+  value: string;
+  width: number;
+  tone: "teal" | "blue" | "gold";
+}) {
+  return (
+    <div className={`bar-row ${props.tone}`}>
+      <div className="bar-label">
+        <span>{props.label}</span>
+        <strong>{props.value}</strong>
+      </div>
+      <div className="bar-track">
+        <span style={{ "--bar-width": `${Math.max(4, props.width)}%` } as CSSProperties} />
+      </div>
+    </div>
+  );
+}
+
+function TokenStack({ usage }: { usage?: TokenUsage }) {
+  if (!usage) {
+    return <EmptyState>No token event recorded.</EmptyState>;
+  }
+  const max = Math.max(usage.inputTokens, usage.cachedInputTokens, usage.outputTokens, usage.reasoningOutputTokens, 1);
+  return (
+    <div className="token-stack">
+      <BarRow label="Input" value={formatCompact(usage.inputTokens)} width={(usage.inputTokens / max) * 100} tone="blue" />
+      <BarRow label="Cached" value={formatCompact(usage.cachedInputTokens)} width={(usage.cachedInputTokens / max) * 100} tone="teal" />
+      <BarRow label="Output" value={formatCompact(usage.outputTokens)} width={(usage.outputTokens / max) * 100} tone="gold" />
+      <div className="token-total">
+        <span>Total</span>
+        <strong>{formatCompact(usage.totalTokens)}</strong>
+      </div>
+    </div>
+  );
+}
+
+function EmptyState({ children }: { children: ReactNode }) {
+  return <p className="empty-state">{children}</p>;
+}
+
+function interactionsForProject(sessionDetails: SessionDetail[], project: string): BrowseInteraction[] {
+  return sessionDetails
+    .filter((session) => project === allProjectsName || session.project === project)
+    .flatMap((session) =>
+      session.interactions.map((interaction) => ({
+        ...interaction,
+        project: session.project,
+        cwd: session.cwd,
+        sessionFirstSeen: session.firstSeen
+      }))
+    )
+    .sort((a, b) => (b.timestamp ?? "").localeCompare(a.timestamp ?? ""));
+}
+
+function searchMessages(
+  messages: MessageSearchResult[],
+  project: string,
+  query: string,
+  role: SearchRole
+) {
+  const normalizedQuery = query.trim().toLowerCase();
+  return messages.filter((message) => {
+    if (project !== allProjectsName && message.project !== project) {
+      return false;
+    }
+    if (role !== "all" && message.role !== role) {
+      return false;
+    }
+    if (!normalizedQuery) {
+      return true;
+    }
+    return `${message.content} ${message.snippet} ${message.project}`.toLowerCase().includes(normalizedQuery);
+  });
+}
+
+function activityRange(summary: ProjectSummary) {
+  const first = formatShortDate(summary.activity.firstSeen);
+  const last = formatShortDate(summary.activity.lastSeen);
+  if (!first || !last) {
+    return "No activity";
+  }
+  return `${first} to ${last}`;
+}
+
+function shortDate(value: string) {
+  const date = new Date(`${value}T12:00:00`);
+  return new Intl.DateTimeFormat("en", { month: "short", day: "numeric" }).format(date);
+}
+
+function formatShortDate(value?: string) {
+  if (!value) {
+    return "";
+  }
+  return new Intl.DateTimeFormat("en", { month: "short", day: "numeric" }).format(new Date(value));
+}
+
+function formatDateTime(value?: string) {
+  if (!value) {
+    return "No timestamp";
+  }
+  return new Intl.DateTimeFormat("en", {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit"
+  }).format(new Date(value));
+}
+
+function formatDuration(value?: number) {
+  if (!value) {
+    return "No duration";
+  }
+  if (value < 1000) {
+    return `${value} ms`;
+  }
+  return `${Math.round(value / 1000)} sec`;
+}
+
+function formatNumber(value: number) {
+  return new Intl.NumberFormat("en").format(value);
+}
+
+function formatCompact(value: number) {
+  return new Intl.NumberFormat("en", { notation: "compact", maximumFractionDigits: 1 }).format(value);
+}
+
+function downloadSummaryJson(summary: ProjectSummary) {
+  downloadFile(
+    `codex-log-viewer-${slug(summary.project)}-synthetic.json`,
+    `${JSON.stringify({ summary, privacy: demoData.source.privacy }, null, 2)}\n`,
+    "application/json"
+  );
+}
+
+function downloadSummaryCsv(summary: ProjectSummary) {
+  const rows = [
+    ["metric", "value"],
+    ["project", summary.project],
+    ["sessions", summary.totals.sessions],
+    ["userMessages", summary.totals.userMessages],
+    ["uniqueUserMessages", summary.totals.uniqueUserMessages],
+    ["toolEvents", summary.totals.toolEvents],
+    ["parseWarnings", summary.totals.parseWarnings],
+    ["totalTokens", summary.tokens.totalTokens],
+    ["inputTokens", summary.tokens.inputTokens],
+    ["cachedInputTokens", summary.tokens.cachedInputTokens],
+    ["outputTokens", summary.tokens.outputTokens]
+  ];
+  downloadFile(
+    `codex-log-viewer-${slug(summary.project)}-synthetic.csv`,
+    rows.map((row) => row.map(csvCell).join(",")).join("\n") + "\n",
+    "text/csv"
+  );
+}
+
+function downloadFile(filename: string, body: string, type: string) {
+  const blob = new Blob([body], { type });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.style.display = "none";
+  document.body.append(anchor);
+  anchor.click();
+  anchor.remove();
+  window.setTimeout(() => URL.revokeObjectURL(url), 0);
+}
+
+function csvCell(value: string | number) {
+  const text = String(value);
+  return /[",\n]/.test(text) ? `"${text.replaceAll('"', '""')}"` : text;
+}
+
+function slug(value: string) {
+  return value.toLowerCase().replaceAll(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "") || "all-projects";
+}

--- a/apps/web-demo/src/App.tsx
+++ b/apps/web-demo/src/App.tsx
@@ -1,16 +1,18 @@
 import type { CSSProperties, ReactNode } from "react";
 import { useEffect, useMemo, useState } from "react";
 import {
-  Activity,
-  BarChart3,
+  CalendarDays,
+  CheckCircle2,
   Code2,
   Download,
   ExternalLink,
   FileText,
-  ListTree,
+  Folder,
+  Grid2X2,
   Search,
+  Send,
   ShieldCheck,
-  Terminal,
+  Wand2,
   Wrench
 } from "lucide-react";
 import demoDataRaw from "./data/demo-data.generated.json";
@@ -35,11 +37,11 @@ interface BrowseInteraction extends DemoInteraction {
 
 const demoData = demoDataRaw as DemoData;
 const allProjectsName = "All Projects";
-const sections: Array<{ id: Section; label: string; icon: typeof BarChart3 }> = [
-  { id: "overview", label: "Overview", icon: BarChart3 },
-  { id: "browse", label: "Browse", icon: ListTree },
-  { id: "search", label: "Search", icon: Search },
-  { id: "audit", label: "Audit", icon: FileText }
+const sections: Array<{ id: Section; label: string }> = [
+  { id: "browse", label: "Browse" },
+  { id: "overview", label: "Overview" },
+  { id: "search", label: "Search" },
+  { id: "audit", label: "Audit" }
 ];
 
 export default function App() {
@@ -80,35 +82,49 @@ export default function App() {
 
   return (
     <div className="site-page">
-      <SiteHeader />
-
       <div className="app-shell">
         <aside className="sidebar">
-          <div className="brand">
+          <div className="sidebar-title">
             <img src="./app-icon.svg" alt="" />
             <div>
-              <strong>Codex Log Viewer</strong>
-              <span>Static synthetic demo</span>
+              <h2>Codex Logs</h2>
+              <p>Static synthetic demo</p>
             </div>
           </div>
 
-          <nav className="project-nav" aria-label="Projects">
+          <div className="sidebar-section">
+            <span className="sidebar-section-label">Library</span>
             <ProjectButton
               active={selectedProject === allProjectsName}
+              icon={<Grid2X2 size={15} aria-hidden="true" />}
               label={allProjectsName}
+              count={demoData.summaries[allProjectsName].totals.userMessages}
               meta={`${demoData.summaries[allProjectsName].totals.sessions} sessions`}
               onClick={() => setSelectedProject(allProjectsName)}
             />
-            {demoData.projects.map((project) => (
-              <ProjectButton
-                key={project.project}
-                active={selectedProject === project.project}
-                label={project.project}
-                meta={`${project.messages} prompts`}
-                onClick={() => setSelectedProject(project.project)}
-              />
-            ))}
-          </nav>
+          </div>
+
+          <div className="sidebar-section">
+            <div className="project-section-header">
+              <span>Projects</span>
+              <button type="button" aria-label="Sort projects by messages">
+                Sort: Messages
+              </button>
+            </div>
+            <nav className="project-nav" aria-label="Projects">
+              {demoData.projects.map((project) => (
+                <ProjectButton
+                  key={project.project}
+                  active={selectedProject === project.project}
+                  icon={<Folder size={15} aria-hidden="true" />}
+                  label={project.project}
+                  count={project.messages}
+                  meta={`${project.sessions} sessions`}
+                  onClick={() => setSelectedProject(project.project)}
+                />
+              ))}
+            </nav>
+          </div>
 
           <div className="sidebar-footer">
             <div className="source-pill">
@@ -132,12 +148,16 @@ export default function App() {
           <header className="workspace-header">
             <div className="workspace-title">
               <h1>{summary.project}</h1>
-              <p>{activityRange(summary)} · {demoData.source.fixturePath}</p>
+              <p>{activityRange(summary)} <span aria-hidden="true">·</span> Up to date.</p>
             </div>
+
+            <button className="date-range-button" type="button">
+              <CalendarDays size={15} aria-hidden="true" />
+              <span>All Time</span>
+            </button>
 
             <div className="section-tabs" role="tablist" aria-label="Sections">
               {sections.map((section) => {
-                const Icon = section.icon;
                 return (
                   <button
                     key={section.id}
@@ -149,7 +169,6 @@ export default function App() {
                     type="button"
                     onClick={() => setSelectedSection(section.id)}
                   >
-                    <Icon size={16} aria-hidden="true" />
                     {section.label}
                   </button>
                 );
@@ -185,44 +204,11 @@ export default function App() {
   );
 }
 
-function SiteHeader() {
-  const links = [
-    { label: "Ask Me Anything", href: "/ask" },
-    { label: "Writing", href: "/writing" },
-    { label: "Notes", href: "/posts" },
-    { label: "Projects", href: "/projects" },
-    { label: "Photography", href: "/photography" }
-  ];
-
-  return (
-    <header className="site-header">
-      <div className="site-top-bar" />
-      <div className="site-nav">
-        <a className="site-brand" href="/">
-          <span className="site-logo-mark" aria-hidden="true" />
-          <span>Cristiano Pierry</span>
-        </a>
-        <nav className="site-links" aria-label="Personal website">
-          {links.map((link) => (
-            <a key={link.href} href={link.href}>
-              {link.label}
-            </a>
-          ))}
-        </nav>
-      </div>
-      <div className="site-network-band" aria-hidden="true">
-        <span className="network-node node-a" />
-        <span className="network-node node-b" />
-        <span className="network-node node-c" />
-        <span className="network-node node-d" />
-      </div>
-    </header>
-  );
-}
-
 function ProjectButton(props: {
   active: boolean;
+  icon: ReactNode;
   label: string;
+  count: number;
   meta: string;
   onClick: () => void;
 }) {
@@ -232,85 +218,164 @@ function ProjectButton(props: {
       type="button"
       aria-pressed={props.active}
       onClick={props.onClick}
+      title={`${props.label}: ${props.count.toLocaleString()} sent messages, ${props.meta}`}
     >
-      <span>{props.label}</span>
-      <small>{props.meta}</small>
+      <span className="project-icon">{props.icon}</span>
+      <span className="project-title">{props.label}</span>
+      <span className="message-count-badge">{formatNumber(props.count)}</span>
     </button>
   );
 }
 
 function Overview({ summary }: { summary: ProjectSummary }) {
-  const maxDailyMessages = Math.max(...summary.messagesByDay.map((bucket) => bucket.count), 1);
+  const [showsAllCategories, setShowsAllCategories] = useState(false);
+  const hourlyMessages = hourlyCounts(summary);
+  const weekdayMessages = weekdayCounts(summary);
+  const hourlyTokens = hourlyTokenCounts(summary);
+  const maxHourlyMessages = Math.max(...hourlyMessages.map((bucket) => bucket.count), 1);
+  const maxWeekdayMessages = Math.max(...weekdayMessages.map((bucket) => bucket.count), 1);
+  const maxHourlyTokens = Math.max(...hourlyTokens.map((bucket) => bucket.input + bucket.output), 1);
+  const maxHourlyOutput = Math.max(...hourlyTokens.map((bucket) => bucket.output), 1);
   const maxIntentCount = Math.max(...summary.promptIntents.buckets.map((bucket) => bucket.count), 1);
-  const maxModelTokens = Math.max(...summary.models.map((model) => model.tokens.totalTokens), 1);
+  const leadingBucket = summary.promptIntents.buckets[0];
+  const visibleBuckets = showsAllCategories
+    ? summary.promptIntents.buckets
+    : summary.promptIntents.buckets.slice(0, 7);
 
   return (
     <section className="section-stack">
       <div className="metrics-grid">
-        <Metric icon={<Activity size={18} />} label="Sessions" value={formatNumber(summary.totals.sessions)} />
-        <Metric icon={<ListTree size={18} />} label="User prompts" value={formatNumber(summary.totals.userMessages)} />
-        <Metric icon={<BarChart3 size={18} />} label="Total tokens" value={formatCompact(summary.tokens.totalTokens)} />
-        <Metric icon={<Search size={18} />} label="Unique prompts" value={formatNumber(summary.totals.uniqueUserMessages)} />
-        <Metric icon={<Wrench size={18} />} label="Tool events" value={formatNumber(summary.totals.toolEvents)} />
-        <Metric icon={<Terminal size={18} />} label="Warnings" value={formatNumber(summary.totals.parseWarnings)} tone="warn" />
+        <Metric label="Sessions" value={formatNumber(summary.totals.sessions)} />
+        <Metric label="Sent Messages" value={formatNumber(summary.totals.userMessages)} />
+        <Metric label="Automations" value={formatNumber(summary.totals.automationMessages)} />
+        <Metric label="Unique Messages" value={formatNumber(summary.totals.uniqueUserMessages)} />
+        <Metric label="Total Tokens" value={formatNumber(summary.tokens.totalTokens)} />
+        <Metric label="Fresh Input" value={formatNumber(summary.tokens.freshInputTokens)} />
+        <Metric label="Cached Input" value={formatNumber(summary.tokens.cachedInputTokens)} />
+        <Metric label="Output Tokens" value={formatNumber(summary.tokens.outputTokens)} />
+        <Metric label="Reasoning Tokens" value={formatNumber(summary.tokens.reasoningOutputTokens)} />
       </div>
 
-      <div className="overview-grid">
-        <Panel title="Activity By Day">
-          <div className="bar-list">
-            {summary.messagesByDay.map((bucket) => (
-              <BarRow
-                key={bucket.key}
-                label={shortDate(bucket.key)}
-                value={`${bucket.count} prompts`}
-                width={(bucket.count / maxDailyMessages) * 100}
-                tone="teal"
-              />
-            ))}
+      <Panel title="Project Focus" className="project-focus-panel">
+        <div className="project-focus-header">
+          <div>
+            <strong>{formatNumber(summary.promptIntents.totalMessages)} prompts analyzed</strong>
+            <span>{classificationSubtitle(summary)}</span>
           </div>
-        </Panel>
+          {leadingBucket && (
+            <span className="top-category-pill">
+              <span className={`intent-dot ${intentClass(leadingBucket.key)}`} />
+              Top: {leadingBucket.label}
+            </span>
+          )}
+        </div>
 
-        <Panel title="Model Usage">
-          <div className="bar-list">
-            {summary.models.map((model) => (
+        <div className="project-focus-body">
+          <ProjectFocusDonut summary={summary} />
+          <div className="project-focus-list">
+            {visibleBuckets.map((bucket) => (
+              <div className="focus-row" key={bucket.key}>
+                <div className="focus-row-title">
+                  <span className={`intent-dot ${intentClass(bucket.key)}`} />
+                  <strong>{bucket.label}</strong>
+                  <span>{formatNumber(bucket.count)} · {bucket.percentage.toFixed(1)}%</span>
+                </div>
+                <div className="native-progress">
+                  <span
+                    className={intentClass(bucket.key)}
+                    style={{ "--bar-width": `${Math.max(3, (bucket.count / maxIntentCount) * 100)}%` } as CSSProperties}
+                  />
+                </div>
+                <small>
+                  {formatNumber(bucket.sessionCount)} {bucket.sessionCount === 1 ? "session" : "sessions"}
+                  {bucket.examples[0] ? `   ${bucket.examples[0]}` : ""}
+                </small>
+              </div>
+            ))}
+            {summary.promptIntents.buckets.length > 7 && (
+              <button
+                className="show-categories-button"
+                type="button"
+                onClick={() => setShowsAllCategories((current) => !current)}
+              >
+                {showsAllCategories
+                  ? "Show fewer categories"
+                  : `Show all ${summary.promptIntents.buckets.length} categories`}
+              </button>
+            )}
+          </div>
+        </div>
+      </Panel>
+
+      <Panel title="Charts" className="charts-panel">
+        <div className="chart-panel-list">
+          <ChartPanel title="Messages by Hour">
+            {hourlyMessages.map((bucket) => (
               <BarRow
-                key={model.model}
-                label={model.model}
-                value={`${formatCompact(model.tokens.totalTokens)} tokens`}
-                width={(model.tokens.totalTokens / maxModelTokens) * 100}
+                key={bucket.hour}
+                label={hourLabel(bucket.hour)}
+                value={`${bucket.count} messages`}
+                width={(bucket.count / maxHourlyMessages) * 100}
                 tone="blue"
               />
             ))}
-          </div>
-        </Panel>
+          </ChartPanel>
 
-        <Panel title="Project Focus">
-          <div className="bar-list">
-            {summary.promptIntents.buckets.slice(0, 7).map((bucket) => (
+          <ChartPanel title="Messages by Day of Week">
+            {weekdayMessages.map((bucket) => (
               <BarRow
-                key={bucket.key}
+                key={bucket.label}
                 label={bucket.label}
-                value={`${bucket.count} · ${bucket.percentage}%`}
-                width={(bucket.count / maxIntentCount) * 100}
+                value={`${bucket.count} messages`}
+                width={(bucket.count / maxWeekdayMessages) * 100}
+                tone="teal"
+              />
+            ))}
+          </ChartPanel>
+
+          <ChartPanel title="Tokens by Hour">
+            {hourlyTokens.map((bucket) => (
+              <BarRow
+                key={bucket.hour}
+                label={hourLabel(bucket.hour)}
+                value={`${formatCompact(bucket.input + bucket.output)} tokens`}
+                width={((bucket.input + bucket.output) / maxHourlyTokens) * 100}
                 tone="gold"
               />
             ))}
-          </div>
-        </Panel>
+          </ChartPanel>
 
-        <Panel title="Repeated Prompts">
-          <div className="repeat-list">
-            {summary.repeatedUserMessages.length > 0 ? summary.repeatedUserMessages.map((item) => (
-              <div className="repeat-row" key={item.id}>
-                <strong>{item.sample}</strong>
-                <span>{item.count} uses across {item.sessionCount} sessions</span>
+          <ChartPanel title="Output Tokens by Hour">
+            {hourlyTokens.map((bucket) => (
+              <BarRow
+                key={bucket.hour}
+                label={hourLabel(bucket.hour)}
+                value={`${formatCompact(bucket.output)} output`}
+                width={(bucket.output / maxHourlyOutput) * 100}
+                tone="teal"
+              />
+            ))}
+          </ChartPanel>
+        </div>
+      </Panel>
+
+      <Panel title="Repeated Prompts">
+        <div className="repeat-list">
+          {summary.repeatedUserMessages.length > 0 ? summary.repeatedUserMessages.slice(0, 5).map((item) => (
+            <div className="repeat-row" key={item.id}>
+              <div>
+                <span>{item.count} repeats</span>
+                <span>{item.sessionCount} sessions</span>
               </div>
-            )) : (
-              <EmptyState>No repeated prompts in this project slice.</EmptyState>
-            )}
-          </div>
-        </Panel>
-      </div>
+              <strong>{item.sample}</strong>
+              <small>{item.projects.join(", ")}</small>
+            </div>
+          )) : (
+            <EmptyState>No repeated prompts in this project slice.</EmptyState>
+          )}
+        </div>
+      </Panel>
+
     </section>
   );
 }
@@ -323,9 +388,9 @@ function Browse(props: {
   return (
     <section className="browser-grid">
       <div className="list-panel">
-        <div className="panel-heading">
-          <h2>Submitted Prompts</h2>
-          <span>{props.interactions.length}</span>
+        <div className="column-title">
+          <Send size={19} aria-hidden="true" />
+          <h2>User Messages</h2>
         </div>
         <div className="prompt-list">
           {props.interactions.map((interaction) => (
@@ -335,18 +400,29 @@ function Browse(props: {
               type="button"
               onClick={() => props.onSelect(interaction.id)}
             >
+              <span className="prompt-row-meta">
+                <PromptIntentBadge label={interaction.promptIntent} intentKey={interaction.promptIntentKey} />
+                <span>{interaction.project}</span>
+                <span>{formatDateTime(interaction.timestamp)}</span>
+                <span>{interaction.model}</span>
+              </span>
               <strong>{interaction.userMessage}</strong>
-              <span>{interaction.project} · {formatDateTime(interaction.timestamp)}</span>
-              <small>{interaction.promptIntent}</small>
             </button>
           ))}
         </div>
+        <BrowserStatusBar title="User Messages" subtitle={`${formatNumber(props.interactions.length)} sent`} />
       </div>
 
       <div className="detail-panel">
-        {props.selectedInteraction ? <InteractionDetail interaction={props.selectedInteraction} /> : (
-          <EmptyState>No submitted prompts are available for this project.</EmptyState>
-        )}
+        <div className="interaction-scroll">
+          {props.selectedInteraction ? <InteractionDetail interaction={props.selectedInteraction} /> : (
+            <EmptyState>No submitted prompts are available for this project.</EmptyState>
+          )}
+        </div>
+        <BrowserStatusBar
+          title="Codex Interaction"
+          subtitle={props.selectedInteraction ? interactionSubtitle(props.selectedInteraction) : undefined}
+        />
       </div>
     </section>
   );
@@ -413,130 +489,253 @@ function SearchSection(props: {
   onRoleChange: (value: SearchRole) => void;
   onSelect: (id: string) => void;
 }) {
+  const roleOptions: Array<{ value: SearchRole; label: string }> = [
+    { value: "all", label: "All" },
+    { value: "user", label: "User Sent" },
+    { value: "automation", label: "Automation" },
+    { value: "assistant", label: "Assistant" },
+    { value: "system", label: "System" },
+    { value: "developer", label: "Developer" }
+  ];
+
   return (
     <section className="search-layout">
-      <div className="search-toolbar">
-        <label className="search-input">
-          <Search size={17} aria-hidden="true" />
-          <input
-            value={props.query}
-            onChange={(event) => props.onQueryChange(event.target.value)}
-            aria-label="Search messages"
-            placeholder="Search synthetic messages"
-          />
-        </label>
-        <select
-          value={props.role}
-          aria-label="Message role"
-          onChange={(event) => props.onRoleChange(event.target.value as SearchRole)}
-        >
-          <option value="all">All roles</option>
-          <option value="user">User</option>
-          <option value="assistant">Assistant</option>
-          <option value="developer">Developer</option>
-        </select>
-        <span className="result-count">{props.results.length} matches</span>
-      </div>
+      <Panel title="Message Search">
+        <div className="search-toolbar">
+          <label className="search-input">
+            <Search size={17} aria-hidden="true" />
+            <input
+              value={props.query}
+              onChange={(event) => props.onQueryChange(event.target.value)}
+              aria-label="Search messages"
+              placeholder="Search messages across projects"
+            />
+          </label>
+          <button className="native-button" type="button">Search</button>
+        </div>
 
-      <div className="search-grid">
-        <div className="search-results">
-          {props.results.map((result) => (
+        <div className="search-filter-row" role="group" aria-label="Message role">
+          {roleOptions.map((option) => (
             <button
-              key={result.id}
-              className={result.id === props.selectedResult?.id ? "search-row active" : "search-row"}
+              key={option.value}
+              className={props.role === option.value ? "active" : ""}
               type="button"
-              onClick={() => props.onSelect(result.id)}
+              aria-pressed={props.role === option.value}
+              onClick={() => props.onRoleChange(option.value)}
             >
-              <span>{result.role}</span>
-              <strong>{result.snippet}</strong>
-              <small>{result.project} · {formatDateTime(result.timestamp)}</small>
+              {option.label}
             </button>
           ))}
         </div>
 
-        <div className="message-detail">
-          {props.selectedResult ? (
-            <>
-              <div className="detail-title compact">
-                <div>
-                  <p>{props.selectedResult.role}</p>
-                  <h2>{props.selectedResult.project}</h2>
-                </div>
-                {props.selectedResult.promptIntent && <span className="intent-badge">{props.selectedResult.promptIntent}</span>}
+        <p className="search-summary">{formatNumber(props.results.length)} matches in the current project and date filters.</p>
+
+        {props.results.length > 0 ? (
+          <>
+            <div className="search-table" role="table" aria-label="Message search results">
+              <div className="search-table-header" role="row">
+                <span>Date/Time</span>
+                <span>Message</span>
+                <span>Project</span>
+                <span>Role</span>
               </div>
-              <pre>{props.selectedResult.content.trim()}</pre>
-              <div className="detail-meta">
-                <span>{props.selectedResult.model ?? "unknown model"}</span>
-                <span>{props.selectedResult.sourceEvent}</span>
-                <span>{props.selectedResult.sessionId}</span>
+              <div className="search-table-body">
+                {props.results.map((result) => (
+                  <button
+                    key={result.id}
+                    className={result.id === props.selectedResult?.id ? "search-row active" : "search-row"}
+                    type="button"
+                    onClick={() => props.onSelect(result.id)}
+                  >
+                    <span>{compactDateTime(result.timestamp)}</span>
+                    <span>
+                      {result.promptIntent && <PromptIntentBadge label={result.promptIntent} intentKey={result.promptIntentKey} />}
+                      <strong>{result.snippet}</strong>
+                    </span>
+                    <span>{result.project}</span>
+                    <span>{result.role}</span>
+                  </button>
+                ))}
               </div>
-            </>
-          ) : <EmptyState>No matching messages.</EmptyState>}
-        </div>
-      </div>
+            </div>
+
+            <SearchResultDetail result={props.selectedResult} query={props.query} />
+          </>
+        ) : (
+          <EmptyState>No matches. Try another phrase or broaden the current filters.</EmptyState>
+        )}
+      </Panel>
     </section>
   );
 }
 
 function Audit({ summary }: { summary: ProjectSummary }) {
   return (
-    <section className="audit-grid">
-      <div className="audit-main">
-        <div className="panel-heading">
-          <h2>AI Worklog Preview</h2>
-          <span>{demoData.auditPreview.appendedSections} new sections</span>
+    <section className="audit-native">
+      <div className="audit-control-bar">
+        <div className="audit-path-row">
+          <Folder size={16} aria-hidden="true" />
+          <input readOnly value="/Users/example/projects/Codex Log Viewer" aria-label="Repository path" />
+          <button className="icon-button" type="button" aria-label="Choose repository">
+            <Folder size={16} aria-hidden="true" />
+          </button>
+        </div>
+
+        <div className="audit-action-row">
+          <label className="switch-control">
+            <input type="checkbox" checked readOnly />
+            <span>Responses</span>
+          </label>
+
+          <span className="audit-target-path">{demoData.auditPreview.targetPath}</span>
+
+          <button className="native-button" type="button">
+            <Wand2 size={15} aria-hidden="true" />
+            Generate
+          </button>
+          <button className="native-button prominent" type="button">
+            <CheckCircle2 size={15} aria-hidden="true" />
+            Approve
+          </button>
+          <button className="native-button" type="button" onClick={() => downloadSummaryJson(summary)}>
+            <Download size={15} aria-hidden="true" />
+            JSON
+          </button>
+          <button className="native-button" type="button" onClick={() => downloadSummaryCsv(summary)}>
+            <Download size={15} aria-hidden="true" />
+            CSV
+          </button>
+        </div>
+      </div>
+
+      <div className="audit-preview-pane">
+        <div className="audit-preview-header">
+          <div>
+            <h2>Merged Worklog Preview</h2>
+            <p>{demoData.auditPreview.appendedSections} new sections · {demoData.auditPreview.skippedSections} present</p>
+          </div>
+          <span>
+            <FileText size={15} aria-hidden="true" />
+            {demoData.auditPreview.appendedSections} generated
+          </span>
+          <span>
+            <CheckCircle2 size={15} aria-hidden="true" />
+            Public synthetic mode
+          </span>
         </div>
         <pre className="markdown-preview">{demoData.auditPreview.generatedMarkdown}</pre>
       </div>
-
-      <aside className="export-panel">
-        <Panel title="Export Preview">
-          <div className="export-actions">
-            <button type="button" onClick={() => downloadSummaryJson(summary)}>
-              <Download size={17} aria-hidden="true" />
-              JSON
-            </button>
-            <button type="button" onClick={() => downloadSummaryCsv(summary)}>
-              <Download size={17} aria-hidden="true" />
-              CSV
-            </button>
-          </div>
-          <div className="export-facts">
-            <span>Target</span>
-            <strong>{demoData.auditPreview.targetPath}</strong>
-            <span>Privacy</span>
-            <strong>Public synthetic mode</strong>
-            <span>Generated</span>
-            <strong>{formatDateTime(demoData.generatedAt)}</strong>
-          </div>
-        </Panel>
-
-        <Panel title="Current Summary">
-          <TokenStack usage={summary.tokens} />
-        </Panel>
-      </aside>
     </section>
   );
 }
 
-function Metric(props: { icon: ReactNode; label: string; value: string; tone?: "warn" }) {
+function Metric(props: { icon?: ReactNode; label: string; value: string; tone?: "warn" }) {
   return (
     <div className={props.tone === "warn" ? "metric warn" : "metric"}>
-      <span>{props.icon}</span>
+      {props.icon && <span>{props.icon}</span>}
       <div>
-        <strong>{props.value}</strong>
         <small>{props.label}</small>
+        <strong>{props.value}</strong>
       </div>
     </div>
   );
 }
 
-function Panel({ title, children }: { title: string; children: ReactNode }) {
+function Panel({ title, children, className }: { title: string; children: ReactNode; className?: string }) {
   return (
-    <section className="panel">
+    <section className={className ? `panel ${className}` : "panel"}>
       <h2>{title}</h2>
       {children}
     </section>
+  );
+}
+
+function ProjectFocusDonut({ summary }: { summary: ProjectSummary }) {
+  const total = Math.max(summary.promptIntents.totalMessages, 1);
+  let cursor = 0;
+  const stops = summary.promptIntents.buckets.map((bucket) => {
+    const start = cursor;
+    const end = cursor + (bucket.count / total) * 100;
+    cursor = end;
+    return `${intentColor(bucket.key)} ${start.toFixed(2)}% ${end.toFixed(2)}%`;
+  });
+  const gradient = stops.length > 0
+    ? stops.join(", ")
+    : "rgba(255, 255, 255, 0.16) 0% 100%";
+
+  return (
+    <div
+      className="project-focus-donut"
+      aria-label={`${formatNumber(summary.promptIntents.totalMessages)} prompts analyzed`}
+      style={{ "--donut-gradient": gradient } as CSSProperties}
+    >
+      <div className="donut-center">
+        <strong>{formatNumber(summary.promptIntents.totalMessages)}</strong>
+        <span>prompts</span>
+      </div>
+    </div>
+  );
+}
+
+function ChartPanel({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <section className="chart-panel">
+      <h3>{title}</h3>
+      <div className="bar-list">{children}</div>
+    </section>
+  );
+}
+
+function BrowserStatusBar({ title, subtitle }: { title: string; subtitle?: string }) {
+  return (
+    <div className="browser-status-bar">
+      <strong>{title}</strong>
+      {subtitle && <span>{subtitle}</span>}
+    </div>
+  );
+}
+
+function PromptIntentBadge({ intentKey, label }: { intentKey?: string; label?: string }) {
+  if (!label) {
+    return null;
+  }
+  return <span className={`prompt-intent-badge ${intentClass(intentKey)}`}>{label}</span>;
+}
+
+function SearchResultDetail({ result, query }: { result?: MessageSearchResult; query: string }) {
+  if (!result) {
+    return <EmptyState>Select a search result to inspect the full message.</EmptyState>;
+  }
+
+  return (
+    <div className="search-result-detail">
+      <h3>Selected Result</h3>
+      <div className={`selected-message-card ${intentClass(result.promptIntentKey)}`}>
+        <div className="selected-message-meta">
+          {result.promptIntent && <PromptIntentBadge label={result.promptIntent} intentKey={result.promptIntentKey} />}
+          <span>{result.project}</span>
+          <span>{formatDateTime(result.timestamp)}</span>
+        </div>
+        <p>{highlightlessPreview(result.content, query)}</p>
+      </div>
+      <div className="search-metadata-grid">
+        <MetadataItem label="Date/Time" value={formatDateTime(result.timestamp)} />
+        {result.promptIntent && <MetadataItem label="Category" value={result.promptIntent} />}
+        <MetadataItem label="Project" value={result.project} />
+        <MetadataItem label="Role" value={result.role} />
+        <MetadataItem label="Session Day" value={result.dateKey} />
+        <MetadataItem label="Session ID" value={result.sessionId.slice(0, 8)} />
+      </div>
+    </div>
+  );
+}
+
+function MetadataItem({ label, value }: { label: string; value?: string }) {
+  return (
+    <div>
+      <span>{label}</span>
+      <strong>{value || "Unknown"}</strong>
+    </div>
   );
 }
 
@@ -616,13 +815,159 @@ function searchMessages(
   });
 }
 
+function interactionSubtitle(interaction: BrowseInteraction) {
+  const responseCount = interaction.assistantMessage ? 1 : 0;
+  const responseLabel = `${responseCount} ${responseCount === 1 ? "response" : "responses"}`;
+  if (interaction.tools.length > 0) {
+    return `${responseLabel} · ${interaction.tools.length} ${interaction.tools.length === 1 ? "tool" : "tools"}`;
+  }
+  return responseLabel;
+}
+
+function hourlyCounts(summary: ProjectSummary) {
+  const counts = Array.from({ length: 24 }, (_, hour) => ({ hour, count: 0 }));
+  for (const bucket of summary.messagesByHour) {
+    const hour = bucketHour(bucket.key);
+    if (hour !== undefined) {
+      counts[hour].count += bucket.count;
+    }
+  }
+  return counts.filter((bucket) => bucket.count > 0);
+}
+
+function hourlyTokenCounts(summary: ProjectSummary) {
+  const counts = Array.from({ length: 24 }, (_, hour) => ({ hour, input: 0, output: 0 }));
+  for (const bucket of summary.messagesByHour) {
+    const hour = bucketHour(bucket.key);
+    if (hour !== undefined) {
+      counts[hour].input += bucket.tokens.inputTokens;
+      counts[hour].output += bucket.tokens.outputTokens;
+    }
+  }
+  return counts.filter((bucket) => bucket.input > 0 || bucket.output > 0);
+}
+
+function weekdayCounts(summary: ProjectSummary) {
+  const counts = Array.from({ length: 7 }, (_, index) => ({
+    index,
+    label: new Intl.DateTimeFormat("en", { weekday: "short" }).format(new Date(Date.UTC(2026, 0, 4 + index))),
+    count: 0
+  }));
+  for (const bucket of summary.messagesByDay) {
+    const day = new Date(`${bucket.key}T12:00:00`);
+    if (!Number.isNaN(day.getTime())) {
+      counts[day.getDay()].count += bucket.count;
+    }
+  }
+  return counts.filter((bucket) => bucket.count > 0);
+}
+
+function bucketHour(key: string) {
+  const match = key.match(/T(\d{2})/);
+  if (!match) {
+    return undefined;
+  }
+  const hour = Number(match[1]);
+  return Number.isInteger(hour) && hour >= 0 && hour <= 23 ? hour : undefined;
+}
+
+function hourLabel(hour: number) {
+  if (hour === 0) {
+    return "12 AM";
+  }
+  if (hour < 12) {
+    return `${hour} AM`;
+  }
+  if (hour === 12) {
+    return "12 PM";
+  }
+  return `${hour - 12} PM`;
+}
+
+function classificationSubtitle(summary: ProjectSummary) {
+  const classified = formatNumber(summary.promptIntents.classifiedMessages);
+  const unclassified = summary.promptIntents.unclassifiedMessages;
+  if (unclassified === 0) {
+    return `${classified} classified by work type`;
+  }
+  return `${classified} classified · ${formatNumber(unclassified)} other`;
+}
+
+function intentClass(key?: string) {
+  switch (key) {
+    case "feature-design":
+      return "intent-cyan";
+    case "implementation":
+      return "intent-accent";
+    case "bug-fixes":
+      return "intent-red";
+    case "git-commands":
+      return "intent-purple";
+    case "deploy-release":
+    case "deploy-release-run-build":
+    case "run-build-app":
+    case "planning-strategy":
+      return "intent-orange";
+    case "code-review-qa":
+      return "intent-blue";
+    case "research":
+      return "intent-mint";
+    case "documentation":
+      return "intent-brown";
+    case "testing-verification":
+      return "intent-indigo";
+    case "refactor-cleanup":
+      return "intent-pink";
+    case "content-creation":
+      return "intent-teal";
+    case "data-analysis":
+      return "intent-yellow";
+    case "plan-approvals":
+      return "intent-gray";
+    default:
+      return "intent-secondary";
+  }
+}
+
+function intentColor(key?: string) {
+  switch (intentClass(key)) {
+    case "intent-cyan":
+      return "var(--cyan)";
+    case "intent-accent":
+    case "intent-blue":
+      return "var(--blue)";
+    case "intent-red":
+      return "var(--red)";
+    case "intent-purple":
+      return "var(--purple)";
+    case "intent-orange":
+      return "var(--orange)";
+    case "intent-mint":
+      return "var(--mint)";
+    case "intent-brown":
+      return "var(--brown)";
+    case "intent-indigo":
+      return "var(--indigo)";
+    case "intent-pink":
+      return "var(--pink)";
+    case "intent-teal":
+      return "var(--teal)";
+    case "intent-yellow":
+      return "var(--yellow)";
+    case "intent-gray":
+    case "intent-secondary":
+    default:
+      return "var(--secondary)";
+  }
+}
+
 function activityRange(summary: ProjectSummary) {
-  const first = formatShortDate(summary.activity.firstSeen);
-  const last = formatShortDate(summary.activity.lastSeen);
+  const first = formatHeaderDateTime(summary.activity.firstSeen);
+  const last = formatHeaderDateTime(summary.activity.lastSeen);
   if (!first || !last) {
     return "No activity";
   }
-  return `${first} to ${last}`;
+  return `First session ${first} - Last session ${last}`;
 }
 
 function shortDate(value: string) {
@@ -637,12 +982,37 @@ function formatShortDate(value?: string) {
   return new Intl.DateTimeFormat("en", { month: "short", day: "numeric" }).format(new Date(value));
 }
 
+function formatHeaderDateTime(value?: string) {
+  if (!value) {
+    return "";
+  }
+  return new Intl.DateTimeFormat("en", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit"
+  }).format(new Date(value));
+}
+
 function formatDateTime(value?: string) {
   if (!value) {
     return "No timestamp";
   }
   return new Intl.DateTimeFormat("en", {
     month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit"
+  }).format(new Date(value));
+}
+
+function compactDateTime(value?: string) {
+  if (!value) {
+    return "No timestamp";
+  }
+  return new Intl.DateTimeFormat("en", {
+    month: "numeric",
     day: "numeric",
     hour: "numeric",
     minute: "2-digit"
@@ -665,6 +1035,11 @@ function formatNumber(value: number) {
 
 function formatCompact(value: number) {
   return new Intl.NumberFormat("en", { notation: "compact", maximumFractionDigits: 1 }).format(value);
+}
+
+function highlightlessPreview(value: string, query: string) {
+  const text = value.trim();
+  return query.trim() ? text : text;
 }
 
 function downloadSummaryJson(summary: ProjectSummary) {

--- a/apps/web-demo/src/main.tsx
+++ b/apps/web-demo/src/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App";
+import "./styles.css";
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+);

--- a/apps/web-demo/src/styles.css
+++ b/apps/web-demo/src/styles.css
@@ -1,39 +1,50 @@
 :root {
-  color-scheme: light;
+  color-scheme: dark;
   font-family:
-    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
-    sans-serif;
-  background: #eef2f3;
-  color: #1f2933;
+    -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", ui-sans-serif,
+    system-ui, sans-serif;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
-  --bg: #eef2f3;
-  --surface: #ffffff;
-  --surface-muted: #f7f8f6;
-  --ink: #1f2933;
-  --muted: #64707d;
-  --border: #d9e0df;
-  --sidebar: #20252b;
-  --sidebar-soft: #2b3138;
-  --teal: #0f766e;
-  --blue: #2563eb;
-  --gold: #b7791f;
-  --rose: #be123c;
-  --shadow: 0 18px 45px rgba(31, 41, 51, 0.12);
-  --site-chrome-height: 186px;
+  --window-bg: #1b2223;
+  --content-bg: #1b2223;
+  --sidebar-bg: #171d1e;
+  --sidebar-border: rgba(255, 255, 255, 0.08);
+  --control-bg: rgba(255, 255, 255, 0.08);
+  --control-bg-strong: rgba(255, 255, 255, 0.14);
+  --group-bg: #22292b;
+  --group-bg-raised: #252d30;
+  --text: #e6e8e9;
+  --secondary: rgba(230, 232, 233, 0.64);
+  --tertiary: rgba(230, 232, 233, 0.42);
+  --accent: #0a84ff;
+  --blue: #0a84ff;
+  --cyan: #32d5f3;
+  --teal: #14c8cd;
+  --green: #30d158;
+  --orange: #ff8c2a;
+  --red: #ff3b45;
+  --purple: #bf5af2;
+  --indigo: #6474ff;
+  --pink: #ff375f;
+  --yellow: #ffd60a;
+  --brown: #b58a5f;
+  --mint: #14d6c5;
 }
 
 * {
   box-sizing: border-box;
 }
 
+html {
+  background: var(--window-bg);
+}
+
 body {
   min-width: 320px;
   margin: 0;
-  background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.72), rgba(255, 255, 255, 0)) 0 0 / 100% 220px no-repeat,
-    var(--bg);
+  background: var(--window-bg);
+  color: var(--text);
 }
 
 button,
@@ -53,286 +64,193 @@ button {
 
 .site-page {
   min-height: 100vh;
-}
-
-.site-header {
-  position: relative;
-  z-index: 2;
-  border-bottom: 1px solid #e4e6e5;
-  background: #fafafa;
-}
-
-.site-top-bar {
-  height: 14px;
-  background: #263033;
-}
-
-.site-nav {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 28px;
-  min-height: 100px;
-  padding: 0 56px;
-  border-bottom: 1px solid #e6e8e7;
-  background: rgba(250, 250, 250, 0.97);
-}
-
-.site-brand {
-  display: inline-flex;
-  align-items: center;
-  gap: 18px;
-  min-width: 250px;
-  color: #717172;
-  font-size: 1.45rem;
-  font-weight: 500;
-  letter-spacing: 0;
-  line-height: 1;
-  text-decoration: none;
-  text-transform: uppercase;
-  white-space: nowrap;
-}
-
-.site-logo-mark {
-  position: relative;
-  display: inline-block;
-  width: 40px;
-  height: 22px;
-  flex: 0 0 auto;
-}
-
-.site-logo-mark::before,
-.site-logo-mark::after {
-  position: absolute;
-  content: "";
-  border-radius: 999px;
-  transform-origin: left center;
-}
-
-.site-logo-mark::before {
-  top: 5px;
-  left: 1px;
-  width: 36px;
-  height: 8px;
-  background: linear-gradient(90deg, #2c67a4, #e8edf2 44%, #c47b47 46%, #f2d2b4);
-  transform: rotate(8deg);
-}
-
-.site-logo-mark::after {
-  top: 11px;
-  left: 5px;
-  width: 24px;
-  height: 5px;
-  background: #2d3540;
-  transform: rotate(18deg);
-}
-
-.site-links {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: clamp(22px, 3.3vw, 46px);
-  min-width: 0;
-}
-
-.site-links a {
-  color: #737374;
-  font-size: 1.28rem;
-  font-weight: 500;
-  letter-spacing: 0;
-  line-height: 1.2;
-  text-decoration: none;
-  text-transform: uppercase;
-  white-space: nowrap;
-}
-
-.site-links a:hover {
-  color: #263033;
-}
-
-.site-network-band {
-  position: relative;
-  height: 72px;
-  overflow: hidden;
-  background:
-    linear-gradient(154deg, transparent 0 18%, rgba(197, 203, 205, 0.18) 18.2% 18.5%, transparent 18.7%),
-    linear-gradient(24deg, transparent 0 44%, rgba(197, 203, 205, 0.2) 44.2% 44.5%, transparent 44.7%),
-    linear-gradient(174deg, transparent 0 65%, rgba(197, 203, 205, 0.15) 65.2% 65.5%, transparent 65.7%),
-    #f7f7f7;
-}
-
-.network-node {
-  position: absolute;
-  width: 14px;
-  height: 14px;
-  border-radius: 999px;
-  background: #d5d9da;
-  box-shadow: 0 0 0 6px rgba(213, 217, 218, 0.18);
-}
-
-.node-a {
-  left: 15%;
-  top: 28px;
-  background: #d2a37d;
-}
-
-.node-b {
-  left: 36%;
-  top: 24px;
-}
-
-.node-c {
-  right: 23%;
-  top: 18px;
-}
-
-.node-d {
-  right: 6%;
-  top: 10px;
-  background: #d2a37d;
+  background: var(--window-bg);
 }
 
 .app-shell {
   display: grid;
-  grid-template-columns: 280px minmax(0, 1fr);
-  min-height: calc(100vh - var(--site-chrome-height));
+  grid-template-columns: minmax(0, 1fr);
+  min-height: 100vh;
+  background: var(--content-bg);
 }
 
 .sidebar {
   position: sticky;
   top: 0;
-  display: flex;
+  display: none;
   flex-direction: column;
-  gap: 24px;
-  height: calc(100vh - var(--site-chrome-height));
-  padding: 22px;
+  gap: 14px;
+  height: 100vh;
+  padding: 14px 10px;
   overflow-y: auto;
-  background: var(--sidebar);
-  color: #f7faf9;
+  border-right: 1px solid var(--sidebar-border);
+  background: var(--sidebar-bg);
+  color: var(--text);
 }
 
-.brand {
+.sidebar-title {
   display: flex;
   align-items: center;
-  gap: 12px;
-  min-width: 0;
+  gap: 10px;
+  padding: 2px 6px 8px;
 }
 
-.brand img {
-  width: 42px;
-  height: 42px;
-  flex: 0 0 auto;
-  border-radius: 8px;
-  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.22);
+.sidebar-title img {
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
 }
 
-.brand strong,
-.brand span {
-  display: block;
+.sidebar-title h2,
+.sidebar-title p {
+  margin: 0;
+}
+
+.sidebar-title h2 {
   overflow-wrap: anywhere;
+  font-size: 1.05rem;
+  font-weight: 700;
+  letter-spacing: 0;
 }
 
-.brand strong {
-  font-size: 0.98rem;
+.sidebar-title p {
+  margin-top: 1px;
+  color: var(--secondary);
+  font-size: 0.74rem;
 }
 
-.brand span {
-  margin-top: 2px;
-  color: #a8b3bd;
-  font-size: 0.78rem;
+.sidebar-section {
+  display: grid;
+  gap: 4px;
+}
+
+.sidebar-section-label,
+.project-section-header {
+  min-height: 22px;
+  padding: 0 8px;
+  color: var(--secondary);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.project-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.project-section-header button {
+  border: 0;
+  background: transparent;
+  color: var(--secondary);
+  font-size: 0.72rem;
+  font-weight: 600;
 }
 
 .project-nav {
   display: grid;
-  gap: 8px;
+  gap: 2px;
 }
 
 .project-button {
   display: grid;
-  gap: 3px;
+  grid-template-columns: 18px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 7px;
   width: 100%;
-  min-height: 58px;
-  padding: 11px 12px;
-  border: 1px solid transparent;
-  border-radius: 8px;
+  min-height: 30px;
+  padding: 4px 7px;
+  border: 0;
+  border-radius: 7px;
   background: transparent;
   color: inherit;
   text-align: left;
 }
 
 .project-button:hover {
-  background: rgba(255, 255, 255, 0.07);
+  background: rgba(118, 118, 128, 0.1);
 }
 
 .project-button.active {
-  border-color: rgba(255, 255, 255, 0.18);
-  background: #f7faf9;
-  color: var(--ink);
+  background: rgba(10, 132, 255, 0.16);
 }
 
-.project-button span,
-.project-button small {
+.project-icon {
+  display: inline-flex;
+  color: var(--secondary);
+}
+
+.project-button.active .project-icon {
+  color: var(--accent);
+}
+
+.project-title {
   overflow: hidden;
+  font-size: 0.88rem;
+  font-weight: 550;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.project-button span {
+.message-count-badge {
+  min-width: 28px;
+  padding: 2px 6px;
+  border-radius: 6px;
+  background: var(--control-bg);
+  color: var(--secondary);
+  font-size: 0.82rem;
+  font-variant-numeric: tabular-nums;
   font-weight: 700;
-}
-
-.project-button small {
-  color: #91a0ab;
-}
-
-.project-button.active small {
-  color: var(--muted);
+  text-align: center;
 }
 
 .sidebar-footer {
   display: grid;
-  gap: 10px;
+  gap: 6px;
   margin-top: auto;
+  padding-top: 8px;
 }
 
 .source-pill,
 .link-button {
   display: flex;
   align-items: center;
-  gap: 9px;
-  min-height: 40px;
-  padding: 9px 10px;
-  border: 1px solid rgba(255, 255, 255, 0.13);
-  border-radius: 8px;
-  background: var(--sidebar-soft);
-  color: #eef5f3;
-  font-size: 0.86rem;
+  gap: 7px;
+  min-height: 28px;
+  padding: 5px 7px;
+  border-radius: 7px;
+  color: var(--secondary);
+  font-size: 0.78rem;
   text-decoration: none;
 }
 
-.link-button {
-  justify-content: space-between;
+.source-pill {
+  background: rgba(52, 199, 89, 0.1);
+  color: #248a3d;
 }
 
-.link-button span,
-.source-pill span {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+.link-button:hover {
+  background: rgba(118, 118, 128, 0.1);
+  color: var(--text);
 }
 
 .workspace {
   min-width: 0;
-  padding: 22px;
+  background: var(--content-bg);
 }
 
 .workspace-header {
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(260px, 380px);
   align-items: center;
-  justify-content: space-between;
-  gap: 18px;
-  margin-bottom: 18px;
+  gap: 16px;
+  min-height: 73px;
+  padding: 14px 20px;
+  border-bottom: 1px solid var(--sidebar-border);
+  background: rgba(27, 34, 35, 0.94);
 }
 
 .workspace-title {
@@ -341,313 +259,537 @@ button {
 
 .workspace-title h1 {
   margin: 0;
-  overflow-wrap: anywhere;
-  font-size: 1.75rem;
+  overflow: hidden;
+  color: var(--text);
+  font-size: 1.35rem;
+  font-weight: 700;
   letter-spacing: 0;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .workspace-title p {
   margin: 5px 0 0;
-  color: var(--muted);
-  font-size: 0.9rem;
+  overflow: hidden;
+  color: var(--secondary);
+  font-size: 0.76rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.section-tabs {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  min-width: min(100%, 420px);
-  padding: 4px;
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  background: var(--surface);
-}
-
-.section-tabs button {
+.date-range-button,
+.native-button,
+.icon-button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 7px;
-  width: 100%;
-  min-height: 36px;
-  padding: 8px 10px;
+  gap: 6px;
+  min-height: 28px;
+  padding: 4px 10px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 6px;
+  background: var(--control-bg);
+  color: var(--text);
+  font-size: 0.84rem;
+  font-weight: 500;
+}
+
+.native-button.prominent {
+  border-color: rgba(10, 132, 255, 0.55);
+  background: var(--accent);
+  color: #ffffff;
+}
+
+.icon-button {
+  width: 30px;
+  padding: 0;
+}
+
+.section-tabs {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 2px;
+  min-height: 30px;
+  padding: 3px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+  background: var(--control-bg);
+}
+
+.section-tabs button {
+  min-width: 0;
+  min-height: 24px;
   border: 0;
   border-radius: 6px;
   background: transparent;
-  color: var(--muted);
-  font-weight: 700;
+  color: var(--text);
+  font-size: 0.82rem;
+  font-weight: 600;
 }
 
 .section-tabs button.active {
-  background: #26323d;
-  color: #ffffff;
+  background: rgba(255, 255, 255, 0.16);
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.07),
+    0 1px 3px rgba(0, 0, 0, 0.26);
+}
+
+#section-panel {
+  min-height: calc(100vh - 73px);
 }
 
 .section-stack {
   display: grid;
-  gap: 16px;
+  gap: 18px;
+  padding: 20px;
 }
 
 .metrics-grid {
   display: grid;
-  grid-template-columns: repeat(6, minmax(0, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 12px;
+}
+
+.metric,
+.panel {
+  border: 1px solid rgba(255, 255, 255, 0.035);
+  border-radius: 8px;
+  background: var(--group-bg);
 }
 
 .metric {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  min-width: 0;
-  min-height: 92px;
-  padding: 16px;
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  background: var(--surface);
-  box-shadow: 0 6px 18px rgba(31, 41, 51, 0.05);
+  min-height: 86px;
+  padding: 15px 16px;
 }
 
-.metric > span {
+.metric div {
   display: grid;
-  place-items: center;
-  width: 34px;
-  height: 34px;
-  flex: 0 0 auto;
-  border-radius: 8px;
-  background: #e8f3f1;
-  color: var(--teal);
+  gap: 8px;
 }
 
-.metric.warn > span {
-  background: #fff3db;
-  color: var(--gold);
-}
-
-.metric strong,
 .metric small {
-  display: block;
+  color: var(--secondary);
+  font-size: 0.88rem;
+  font-weight: 650;
 }
 
 .metric strong {
-  overflow-wrap: anywhere;
+  overflow: hidden;
+  font-size: 1.48rem;
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.panel {
+  padding: 14px;
+}
+
+.panel > h2 {
+  margin: 0 0 12px;
+  font-size: 1rem;
+  font-weight: 700;
+  letter-spacing: 0;
+}
+
+.project-focus-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.project-focus-header div {
+  display: grid;
+  gap: 4px;
+}
+
+.project-focus-header strong {
+  font-size: 1.18rem;
+}
+
+.project-focus-header span,
+.focus-row small,
+.repeat-row small {
+  color: var(--secondary);
+  font-size: 0.76rem;
+}
+
+.top-category-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  max-width: 260px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: var(--control-bg);
+  color: var(--text);
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.project-focus-panel {
+  min-height: 462px;
+}
+
+.project-focus-body {
+  display: grid;
+  grid-template-columns: minmax(190px, 270px) minmax(0, 1fr);
+  align-items: center;
+  gap: 26px;
+}
+
+.project-focus-donut {
+  position: relative;
+  display: grid;
+  place-items: center;
+  width: min(100%, 240px);
+  aspect-ratio: 1;
+  margin: 4px auto 0;
+  border-radius: 50%;
+  background: conic-gradient(var(--donut-gradient));
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+}
+
+.project-focus-donut::before {
+  position: absolute;
+  inset: 30%;
+  border-radius: inherit;
+  background: var(--group-bg);
+  content: "";
+}
+
+.donut-center {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 2px;
+  color: var(--text);
+  text-align: center;
+}
+
+.donut-center strong {
   font-size: 1.35rem;
+  font-variant-numeric: tabular-nums;
+  font-weight: 750;
 }
 
-.metric small {
-  margin-top: 2px;
-  color: var(--muted);
+.donut-center span {
+  color: var(--secondary);
+  font-size: 0.82rem;
+  font-weight: 650;
 }
 
-.overview-grid {
+.project-focus-list {
+  display: grid;
+  gap: 11px;
+  min-width: 0;
+}
+
+.focus-row {
+  display: grid;
+  gap: 6px;
+}
+
+.focus-row-title {
+  display: grid;
+  grid-template-columns: 10px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+}
+
+.focus-row-title strong {
+  overflow: hidden;
+  font-size: 0.95rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.focus-row-title span:last-child {
+  color: var(--secondary);
+  font-size: 0.78rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.intent-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+.native-progress,
+.bar-track {
+  position: relative;
+  height: 6px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.native-progress > span,
+.bar-track > span {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: var(--bar-width);
+  border-radius: inherit;
+  background: currentColor;
+}
+
+.intent-cyan {
+  color: var(--cyan);
+}
+
+.intent-accent,
+.intent-blue {
+  color: var(--accent);
+}
+
+.intent-red {
+  color: var(--red);
+}
+
+.intent-purple {
+  color: var(--purple);
+}
+
+.intent-orange {
+  color: var(--orange);
+}
+
+.intent-mint {
+  color: var(--mint);
+}
+
+.intent-brown {
+  color: var(--brown);
+}
+
+.intent-indigo {
+  color: var(--indigo);
+}
+
+.intent-pink {
+  color: var(--pink);
+}
+
+.intent-teal {
+  color: var(--teal);
+}
+
+.intent-yellow {
+  color: var(--yellow);
+}
+
+.intent-gray,
+.intent-secondary {
+  color: var(--secondary);
+}
+
+.chart-panel-list {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 16px;
 }
 
-.panel,
-.list-panel,
-.detail-panel,
-.audit-main,
-.export-panel,
-.message-detail {
-  min-width: 0;
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  background: var(--surface);
-  box-shadow: 0 8px 26px rgba(31, 41, 51, 0.06);
-}
-
-.panel {
-  padding: 16px;
-}
-
-.panel h2,
-.panel-heading h2 {
-  margin: 0;
-  font-size: 1rem;
-  letter-spacing: 0;
-}
-
-.bar-list,
-.repeat-list,
-.tool-list,
-.token-stack {
+.chart-panel {
   display: grid;
-  gap: 12px;
-  margin-top: 14px;
+  gap: 8px;
+}
+
+.chart-panel h3 {
+  margin: 0;
+  font-size: 0.94rem;
+  font-weight: 700;
+}
+
+.bar-list {
+  display: grid;
+  gap: 8px;
 }
 
 .bar-row {
   display: grid;
-  gap: 7px;
+  gap: 5px;
+  color: var(--accent);
+}
+
+.bar-row.teal {
+  color: var(--teal);
+}
+
+.bar-row.gold {
+  color: var(--orange);
 }
 
 .bar-label {
   display: flex;
-  align-items: baseline;
   justify-content: space-between;
   gap: 12px;
-  font-size: 0.86rem;
+  color: var(--text);
+  font-size: 0.78rem;
 }
 
-.bar-label span,
-.bar-label strong {
-  min-width: 0;
+.bar-label span {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .bar-label strong {
-  color: var(--muted);
-  font-size: 0.78rem;
+  color: var(--secondary);
+  font-variant-numeric: tabular-nums;
+  font-weight: 500;
+  white-space: nowrap;
 }
 
-.bar-track {
-  height: 9px;
-  overflow: hidden;
-  border-radius: 999px;
-  background: #e8ecec;
-}
-
-.bar-track span {
-  display: block;
-  width: var(--bar-width);
-  height: 100%;
-  border-radius: inherit;
-}
-
-.bar-row.teal .bar-track span {
-  background: var(--teal);
-}
-
-.bar-row.blue .bar-track span {
-  background: var(--blue);
-}
-
-.bar-row.gold .bar-track span {
-  background: var(--gold);
+.repeat-list {
+  display: grid;
+  gap: 10px;
 }
 
 .repeat-row {
   display: grid;
-  gap: 3px;
-  padding: 10px 0;
-  border-bottom: 1px solid var(--border);
+  gap: 4px;
+  padding: 4px 0;
 }
 
-.repeat-row:last-child {
-  border-bottom: 0;
+.show-categories-button {
+  justify-self: start;
+  min-height: 24px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--secondary);
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.show-categories-button:hover {
+  color: var(--text);
+}
+
+.repeat-row div {
+  display: flex;
+  gap: 10px;
+  color: var(--secondary);
+  font-size: 0.76rem;
+  font-weight: 700;
 }
 
 .repeat-row strong {
   overflow-wrap: anywhere;
+  font-size: 0.9rem;
+  font-weight: 500;
 }
 
-.repeat-row span,
-.empty-state {
-  color: var(--muted);
-  font-size: 0.88rem;
-}
-
-.browser-grid,
-.search-grid,
-.audit-grid {
+.browser-grid {
   display: grid;
-  grid-template-columns: minmax(300px, 390px) minmax(0, 1fr);
-  gap: 16px;
-  min-height: calc(100vh - 116px);
+  grid-template-columns: minmax(260px, 380px) minmax(360px, 1fr);
+  min-height: calc(100vh - 73px);
 }
 
 .list-panel,
-.detail-panel,
-.audit-main,
-.message-detail,
-.export-panel {
-  overflow: hidden;
+.detail-panel {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  min-width: 0;
+  background: var(--content-bg);
 }
 
-.panel-heading {
+.list-panel {
+  border-right: 1px solid var(--sidebar-border);
+}
+
+.column-title {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  min-height: 54px;
-  padding: 15px 16px;
-  border-bottom: 1px solid var(--border);
+  gap: 8px;
+  min-height: 55px;
+  padding: 14px 16px 8px;
 }
 
-.panel-heading span,
-.result-count {
-  flex: 0 0 auto;
-  color: var(--muted);
-  font-size: 0.84rem;
+.column-title h2 {
+  margin: 0;
+  font-size: 1.14rem;
   font-weight: 700;
 }
 
-.prompt-list,
-.search-results {
+.prompt-list {
   display: grid;
   align-content: start;
-  max-height: calc(100vh - 172px);
+  gap: 4px;
   overflow-y: auto;
+  padding: 0 8px 8px;
 }
 
-.prompt-row,
-.search-row {
+.prompt-row {
   display: grid;
   gap: 6px;
   width: 100%;
-  padding: 14px 16px;
-  border: 0;
-  border-bottom: 1px solid var(--border);
-  background: transparent;
-  color: var(--ink);
+  padding: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 8px;
+  background:
+    linear-gradient(90deg, currentColor 0 3px, transparent 3px),
+    rgba(255, 255, 255, 0.04);
+  color: var(--secondary);
   text-align: left;
 }
 
-.prompt-row:hover,
-.search-row:hover {
-  background: var(--surface-muted);
+.prompt-row.active {
+  border-color: rgba(10, 132, 255, 0.38);
+  background:
+    linear-gradient(90deg, currentColor 0 3px, transparent 3px),
+    rgba(10, 132, 255, 0.14);
 }
 
-.prompt-row.active,
-.search-row.active {
-  background: #eaf5f3;
+.prompt-row-meta {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  min-width: 0;
+  color: var(--secondary);
+  font-size: 0.73rem;
 }
 
-.prompt-row strong,
-.search-row strong {
-  overflow-wrap: anywhere;
-  line-height: 1.35;
+.prompt-row-meta > span:not(.prompt-intent-badge) {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.prompt-row span,
-.prompt-row small,
-.search-row small,
-.search-row span {
-  color: var(--muted);
-  font-size: 0.78rem;
+.prompt-row strong {
+  display: -webkit-box;
+  overflow: hidden;
+  color: var(--text);
+  font-size: 0.9rem;
+  font-weight: 500;
+  line-height: 1.32;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 4;
 }
 
-.search-row span {
-  width: fit-content;
-  padding: 3px 7px;
-  border-radius: 999px;
-  background: #edf0ef;
-  color: #46515c;
+.prompt-intent-badge {
+  flex: 0 0 auto;
+  color: currentColor;
+  font-size: 0.73rem;
   font-weight: 700;
-  text-transform: capitalize;
+  line-height: 1.2;
+  white-space: nowrap;
 }
 
-.detail-panel {
-  padding: 18px;
+.interaction-scroll {
   overflow-y: auto;
 }
 
 .interaction-detail {
   display: grid;
   gap: 16px;
+  padding: 16px;
 }
 
 .detail-title {
@@ -657,99 +799,85 @@ button {
   gap: 16px;
 }
 
-.detail-title.compact {
-  align-items: center;
+.detail-title p,
+.detail-title h2 {
+  margin: 0;
 }
 
 .detail-title p {
-  margin: 0 0 5px;
-  color: var(--muted);
-  font-size: 0.82rem;
-  font-weight: 700;
+  color: var(--secondary);
+  font-size: 0.78rem;
 }
 
 .detail-title h2 {
-  margin: 0;
+  margin-top: 4px;
   overflow-wrap: anywhere;
-  font-size: 1.3rem;
-  letter-spacing: 0;
+  font-size: 1.1rem;
+  font-weight: 700;
 }
 
 .intent-badge {
-  flex: 0 1 auto;
+  display: inline-flex;
+  align-items: center;
+  flex: 0 0 auto;
   max-width: 220px;
-  padding: 6px 9px;
-  border: 1px solid #d9e6e3;
+  padding: 4px 8px;
   border-radius: 999px;
-  background: #f0faf7;
-  color: var(--teal);
-  font-size: 0.78rem;
-  font-weight: 800;
-  overflow-wrap: anywhere;
-  text-align: center;
+  background: var(--control-bg);
+  color: var(--secondary);
+  font-size: 0.76rem;
+  font-weight: 700;
 }
 
 .detail-meta {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
+  color: var(--secondary);
+  font-size: 0.78rem;
 }
 
 .detail-meta span {
-  padding: 5px 8px;
-  border: 1px solid var(--border);
+  padding: 4px 8px;
   border-radius: 999px;
-  background: #fafafa;
-  color: var(--muted);
-  font-size: 0.78rem;
-  font-weight: 700;
+  background: var(--control-bg);
 }
 
 .response-block {
-  padding: 16px;
-  border: 1px solid var(--border);
+  display: grid;
+  gap: 8px;
+  padding: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.05);
   border-radius: 8px;
-  background: var(--surface-muted);
-}
-
-.response-block.subdued {
-  background: #f7f4ee;
+  background: var(--group-bg);
 }
 
 .response-block h3 {
-  margin: 0 0 8px;
-  font-size: 0.88rem;
+  margin: 0;
+  font-size: 0.92rem;
 }
 
 .response-block p {
   margin: 0;
   overflow-wrap: anywhere;
-  color: #34404c;
-  line-height: 1.55;
+  line-height: 1.45;
 }
 
 .detail-columns {
   display: grid;
-  grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
-  gap: 14px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.tool-list {
+  display: grid;
+  gap: 8px;
 }
 
 .tool-row {
-  display: grid;
-  grid-template-columns: 18px minmax(0, 1fr);
-  gap: 9px;
-  align-items: start;
-  padding: 10px 0;
-  border-bottom: 1px solid var(--border);
-}
-
-.tool-row:last-child {
-  border-bottom: 0;
-}
-
-.tool-row svg {
-  color: var(--blue);
-  margin-top: 2px;
+  display: flex;
+  gap: 8px;
+  min-width: 0;
 }
 
 .tool-row strong,
@@ -759,197 +887,389 @@ button {
 }
 
 .tool-row span {
-  margin-top: 3px;
-  color: var(--muted);
-  font-size: 0.84rem;
+  margin-top: 2px;
+  color: var(--secondary);
+  font-size: 0.78rem;
+}
+
+.token-stack {
+  display: grid;
+  gap: 8px;
 }
 
 .token-total {
   display: flex;
-  align-items: center;
   justify-content: space-between;
   gap: 12px;
-  padding-top: 10px;
-  border-top: 1px solid var(--border);
+  margin-top: 4px;
+  padding-top: 8px;
+  border-top: 1px solid rgba(255, 255, 255, 0.07);
+  color: var(--secondary);
+  font-size: 0.82rem;
 }
 
-.token-total span {
-  color: var(--muted);
+.token-total strong {
+  color: var(--text);
+}
+
+.browser-status-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 25px;
+  padding: 0 10px;
+  border-top: 1px solid var(--sidebar-border);
+  background: rgba(255, 255, 255, 0.035);
+}
+
+.browser-status-bar strong {
+  font-size: 0.74rem;
+}
+
+.browser-status-bar span {
+  overflow: hidden;
+  color: var(--secondary);
+  font-size: 0.68rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .search-layout {
-  display: grid;
-  gap: 14px;
+  padding: 20px;
 }
 
 .search-toolbar {
-  display: flex;
-  align-items: center;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
   gap: 10px;
-  min-width: 0;
-  padding: 12px;
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  background: var(--surface);
+  margin-bottom: 12px;
 }
 
 .search-input {
   display: flex;
   align-items: center;
-  gap: 9px;
-  min-width: 180px;
-  flex: 1 1 auto;
-  min-height: 40px;
-  padding: 0 11px;
-  border: 1px solid var(--border);
+  gap: 8px;
+  min-width: 0;
+  min-height: 36px;
+  padding: 8px;
   border-radius: 8px;
-  background: #ffffff;
+  background: var(--control-bg);
+  color: var(--secondary);
 }
 
-.search-input svg {
-  color: var(--muted);
-  flex: 0 0 auto;
-}
-
-.search-input input,
-.search-toolbar select {
+.search-input input {
   width: 100%;
+  min-width: 0;
   border: 0;
   outline: 0;
   background: transparent;
-  color: var(--ink);
+  color: var(--text);
 }
 
-.search-toolbar select {
-  flex: 0 0 150px;
-  min-height: 40px;
-  padding: 0 10px;
-  border: 1px solid var(--border);
+.search-filter-row {
+  display: inline-grid;
+  grid-template-columns: repeat(6, minmax(0, auto));
+  gap: 2px;
+  max-width: 100%;
+  margin-bottom: 10px;
+  padding: 3px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: 8px;
-  background: #ffffff;
+  background: var(--control-bg);
 }
 
-.message-detail {
+.search-filter-row button {
+  min-height: 24px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text);
+  font-size: 0.78rem;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.search-filter-row button.active {
+  background: rgba(255, 255, 255, 0.16);
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.07),
+    0 1px 3px rgba(0, 0, 0, 0.26);
+}
+
+.search-summary {
+  margin: 0 0 10px;
+  color: var(--secondary);
+  font-size: 0.78rem;
+}
+
+.search-table {
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 8px;
+}
+
+.search-table-header,
+.search-row {
   display: grid;
-  align-content: start;
-  gap: 15px;
-  padding: 18px;
+  grid-template-columns: 128px minmax(0, 1fr) 150px 78px;
+  align-items: stretch;
 }
 
-.message-detail pre,
-.markdown-preview {
-  margin: 0;
-  overflow: auto;
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  background: #20252b;
-  color: #f5fbfa;
-  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+.search-table-header {
+  min-height: 32px;
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--secondary);
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.search-table-header span,
+.search-row > span {
+  min-width: 0;
+  padding: 8px 10px;
+  border-right: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.search-table-header span:last-child,
+.search-row > span:last-child {
+  border-right: 0;
+}
+
+.search-table-body {
+  max-height: 360px;
+  overflow-y: auto;
+}
+
+.search-row {
+  width: 100%;
+  min-height: 54px;
+  border: 0;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  background: var(--group-bg);
+  color: var(--text);
+  text-align: left;
+}
+
+.search-row:hover {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.search-row.active {
+  background: rgba(10, 132, 255, 0.12);
+}
+
+.search-row span {
+  overflow: hidden;
+  font-size: 0.78rem;
+  text-overflow: ellipsis;
+}
+
+.search-row strong {
+  display: -webkit-box;
+  overflow: hidden;
+  margin-top: 4px;
+  color: var(--text);
   font-size: 0.86rem;
-  line-height: 1.55;
+  font-weight: 500;
+  line-height: 1.25;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.search-result-detail {
+  display: grid;
+  gap: 10px;
+  margin-top: 14px;
+  padding-top: 14px;
+  border-top: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+.search-result-detail h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.selected-message-card {
+  display: grid;
+  gap: 8px;
+  padding: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 8px;
+  background:
+    linear-gradient(90deg, currentColor 0 3px, transparent 3px),
+    rgba(255, 255, 255, 0.04);
+}
+
+.selected-message-meta {
+  display: flex;
+  gap: 8px;
+  color: var(--secondary);
+  font-size: 0.76rem;
+}
+
+.selected-message-card p {
+  margin: 0;
+  overflow-wrap: anywhere;
+  color: var(--text);
+  line-height: 1.45;
+}
+
+.search-metadata-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 8px;
+}
+
+.search-metadata-grid div {
+  display: grid;
+  gap: 3px;
+}
+
+.search-metadata-grid span {
+  color: var(--secondary);
+  font-size: 0.72rem;
+}
+
+.search-metadata-grid strong {
+  overflow: hidden;
+  font-size: 0.82rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.audit-native {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  min-height: calc(100vh - 73px);
+  background: var(--content-bg);
+}
+
+.audit-control-bar {
+  display: grid;
+  gap: 12px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--sidebar-border);
+}
+
+.audit-path-row,
+.audit-action-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+.audit-path-row input {
+  width: 100%;
+  min-width: 0;
+  min-height: 30px;
+  padding: 4px 8px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 6px;
+  background: var(--control-bg);
+  color: var(--text);
+}
+
+.switch-control {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--text);
+  font-size: 0.84rem;
+}
+
+.switch-control input {
+  accent-color: var(--accent);
+}
+
+.audit-target-path {
+  overflow: hidden;
+  flex: 1 1 auto;
+  min-width: 80px;
+  color: var(--secondary);
+  font-size: 0.76rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.audit-preview-pane {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  min-height: 0;
+}
+
+.audit-preview-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 18px;
+  border-bottom: 1px solid var(--sidebar-border);
+}
+
+.audit-preview-header div {
+  display: grid;
+  gap: 4px;
+  margin-right: auto;
+}
+
+.audit-preview-header h2,
+.audit-preview-header p {
+  margin: 0;
+}
+
+.audit-preview-header h2 {
+  font-size: 1rem;
+}
+
+.audit-preview-header p,
+.audit-preview-header span {
+  color: var(--secondary);
+  font-size: 0.76rem;
+}
+
+.audit-preview-header span {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.markdown-preview {
+  min-height: 0;
+  margin: 0;
+  padding: 16px 18px;
+  overflow: auto;
+  border: 0;
+  background: var(--content-bg);
+  color: var(--text);
+  font-family: "SF Mono", Menlo, Consolas, monospace;
+  font-size: 0.82rem;
+  line-height: 1.5;
   white-space: pre-wrap;
 }
 
-.message-detail pre {
-  max-height: 48vh;
-  padding: 16px;
-}
-
-.audit-grid {
-  grid-template-columns: minmax(0, 1fr) minmax(280px, 360px);
-}
-
-.audit-main {
-  display: grid;
-  grid-template-rows: auto minmax(0, 1fr);
-}
-
-.markdown-preview {
-  min-height: 520px;
-  max-height: calc(100vh - 182px);
-  border: 0;
-  border-radius: 0;
-  padding: 18px;
-}
-
-.export-panel {
-  display: grid;
-  align-content: start;
-  gap: 16px;
-  border: 0;
-  background: transparent;
-  box-shadow: none;
-}
-
-.export-actions {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 10px;
-  margin-top: 14px;
-}
-
-.export-actions button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  min-height: 40px;
-  border: 1px solid #cfd8d6;
-  border-radius: 8px;
-  background: #26323d;
-  color: #ffffff;
-  font-weight: 800;
-}
-
-.export-facts {
-  display: grid;
-  gap: 6px;
-  margin-top: 16px;
-}
-
-.export-facts span {
-  color: var(--muted);
-  font-size: 0.78rem;
-  font-weight: 800;
-  text-transform: uppercase;
-}
-
-.export-facts strong {
-  overflow-wrap: anywhere;
-  font-size: 0.88rem;
+.empty-state {
+  margin: 0;
+  padding: 22px;
+  color: var(--secondary);
+  text-align: center;
 }
 
 @media (max-width: 1120px) {
-  :root {
-    --site-chrome-height: 218px;
+  .workspace-header {
+    grid-template-columns: minmax(0, 1fr);
   }
 
-  .site-nav {
-    align-items: flex-start;
-    flex-direction: column;
-    justify-content: center;
-    gap: 18px;
-    min-height: 132px;
-    padding: 22px 32px;
+  .date-range-button,
+  .section-tabs {
+    justify-self: start;
   }
 
-  .site-links {
-    flex-wrap: wrap;
-    justify-content: flex-start;
-    gap: 16px 28px;
+  .section-tabs {
+    width: min(100%, 380px);
   }
 
-  .site-links a {
-    font-size: 1rem;
-  }
-
-  .metrics-grid {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
-
-  .overview-grid,
-  .detail-columns {
-    grid-template-columns: 1fr;
+  .browser-grid {
+    grid-template-columns: minmax(240px, 340px) minmax(320px, 1fr);
   }
 }
 
@@ -961,107 +1281,100 @@ button {
   .sidebar {
     position: static;
     height: auto;
+    border-right: 0;
+    border-bottom: 1px solid var(--sidebar-border);
   }
 
   .project-nav {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
-  .sidebar-footer {
-    grid-template-columns: 1fr 1fr;
-  }
-
-  .source-pill {
-    grid-column: 1 / -1;
-  }
-
-  .workspace-header,
-  .search-toolbar,
-  .detail-title {
-    align-items: stretch;
-    flex-direction: column;
-  }
-
-  .section-tabs {
-    min-width: 0;
-    width: 100%;
-  }
-
-  .browser-grid,
-  .search-grid,
-  .audit-grid {
+  .browser-grid {
     grid-template-columns: 1fr;
     min-height: 0;
   }
 
-  .prompt-list,
-  .search-results {
-    max-height: 360px;
+  .list-panel {
+    border-right: 0;
+    border-bottom: 1px solid var(--sidebar-border);
   }
 
-  .markdown-preview {
-    max-height: 520px;
+  .prompt-list {
+    max-height: 380px;
+  }
+
+  .detail-columns,
+  .metrics-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .search-table-header,
+  .search-row {
+    grid-template-columns: 110px minmax(0, 1fr) 70px;
+  }
+
+  .search-table-header span:nth-child(3),
+  .search-row > span:nth-child(3) {
+    display: none;
   }
 }
 
 @media (max-width: 620px) {
-  :root {
-    --site-chrome-height: 251px;
+  .workspace-header,
+  .section-stack,
+  .search-layout,
+  .audit-control-bar {
+    padding-right: 14px;
+    padding-left: 14px;
   }
 
-  .site-nav {
-    padding: 20px 18px;
-  }
-
-  .site-brand {
-    min-width: 0;
-    font-size: 1rem;
-    letter-spacing: 0;
-  }
-
-  .site-links {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    width: 100%;
-    gap: 13px 18px;
-  }
-
-  .site-links a {
-    overflow-wrap: anywhere;
-    white-space: normal;
-  }
-
-  .site-network-band {
-    height: 52px;
-  }
-
-  .workspace,
-  .sidebar {
-    padding: 16px;
-  }
-
-  .metrics-grid,
-  .project-nav,
-  .sidebar-footer,
-  .section-tabs {
+  .project-nav {
     grid-template-columns: 1fr;
   }
 
-  .section-tabs {
-    display: grid;
-  }
-
-  .metrics-grid,
-  .overview-grid {
-    gap: 10px;
-  }
-
-  .search-toolbar select {
-    flex-basis: auto;
+  .section-tabs,
+  .search-filter-row {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
     width: 100%;
   }
 
-  .intent-badge {
-    max-width: none;
+  .search-toolbar,
+  .audit-action-row,
+  .audit-preview-header,
+  .project-focus-header {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .search-table-header,
+  .search-row {
+    grid-template-columns: 92px minmax(0, 1fr);
+  }
+
+  .search-table-header span:nth-child(4),
+  .search-row > span:nth-child(4) {
+    display: none;
+  }
+
+  .audit-action-row,
+  .audit-preview-header {
+    display: grid;
+  }
+
+  .native-button,
+  .date-range-button {
+    width: 100%;
+  }
+
+  .project-focus-body {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .project-focus-donut {
+    width: min(230px, 78vw);
+  }
+
+  .chart-panel-list {
+    grid-template-columns: minmax(0, 1fr);
   }
 }

--- a/apps/web-demo/src/styles.css
+++ b/apps/web-demo/src/styles.css
@@ -1,0 +1,1067 @@
+:root {
+  color-scheme: light;
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+  background: #eef2f3;
+  color: #1f2933;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  --bg: #eef2f3;
+  --surface: #ffffff;
+  --surface-muted: #f7f8f6;
+  --ink: #1f2933;
+  --muted: #64707d;
+  --border: #d9e0df;
+  --sidebar: #20252b;
+  --sidebar-soft: #2b3138;
+  --teal: #0f766e;
+  --blue: #2563eb;
+  --gold: #b7791f;
+  --rose: #be123c;
+  --shadow: 0 18px 45px rgba(31, 41, 51, 0.12);
+  --site-chrome-height: 186px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-width: 320px;
+  margin: 0;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.72), rgba(255, 255, 255, 0)) 0 0 / 100% 220px no-repeat,
+    var(--bg);
+}
+
+button,
+input,
+select {
+  font: inherit;
+}
+
+button,
+a {
+  -webkit-tap-highlight-color: transparent;
+}
+
+button {
+  cursor: pointer;
+}
+
+.site-page {
+  min-height: 100vh;
+}
+
+.site-header {
+  position: relative;
+  z-index: 2;
+  border-bottom: 1px solid #e4e6e5;
+  background: #fafafa;
+}
+
+.site-top-bar {
+  height: 14px;
+  background: #263033;
+}
+
+.site-nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 28px;
+  min-height: 100px;
+  padding: 0 56px;
+  border-bottom: 1px solid #e6e8e7;
+  background: rgba(250, 250, 250, 0.97);
+}
+
+.site-brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 18px;
+  min-width: 250px;
+  color: #717172;
+  font-size: 1.45rem;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 1;
+  text-decoration: none;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.site-logo-mark {
+  position: relative;
+  display: inline-block;
+  width: 40px;
+  height: 22px;
+  flex: 0 0 auto;
+}
+
+.site-logo-mark::before,
+.site-logo-mark::after {
+  position: absolute;
+  content: "";
+  border-radius: 999px;
+  transform-origin: left center;
+}
+
+.site-logo-mark::before {
+  top: 5px;
+  left: 1px;
+  width: 36px;
+  height: 8px;
+  background: linear-gradient(90deg, #2c67a4, #e8edf2 44%, #c47b47 46%, #f2d2b4);
+  transform: rotate(8deg);
+}
+
+.site-logo-mark::after {
+  top: 11px;
+  left: 5px;
+  width: 24px;
+  height: 5px;
+  background: #2d3540;
+  transform: rotate(18deg);
+}
+
+.site-links {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: clamp(22px, 3.3vw, 46px);
+  min-width: 0;
+}
+
+.site-links a {
+  color: #737374;
+  font-size: 1.28rem;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 1.2;
+  text-decoration: none;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.site-links a:hover {
+  color: #263033;
+}
+
+.site-network-band {
+  position: relative;
+  height: 72px;
+  overflow: hidden;
+  background:
+    linear-gradient(154deg, transparent 0 18%, rgba(197, 203, 205, 0.18) 18.2% 18.5%, transparent 18.7%),
+    linear-gradient(24deg, transparent 0 44%, rgba(197, 203, 205, 0.2) 44.2% 44.5%, transparent 44.7%),
+    linear-gradient(174deg, transparent 0 65%, rgba(197, 203, 205, 0.15) 65.2% 65.5%, transparent 65.7%),
+    #f7f7f7;
+}
+
+.network-node {
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  border-radius: 999px;
+  background: #d5d9da;
+  box-shadow: 0 0 0 6px rgba(213, 217, 218, 0.18);
+}
+
+.node-a {
+  left: 15%;
+  top: 28px;
+  background: #d2a37d;
+}
+
+.node-b {
+  left: 36%;
+  top: 24px;
+}
+
+.node-c {
+  right: 23%;
+  top: 18px;
+}
+
+.node-d {
+  right: 6%;
+  top: 10px;
+  background: #d2a37d;
+}
+
+.app-shell {
+  display: grid;
+  grid-template-columns: 280px minmax(0, 1fr);
+  min-height: calc(100vh - var(--site-chrome-height));
+}
+
+.sidebar {
+  position: sticky;
+  top: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  height: calc(100vh - var(--site-chrome-height));
+  padding: 22px;
+  overflow-y: auto;
+  background: var(--sidebar);
+  color: #f7faf9;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+}
+
+.brand img {
+  width: 42px;
+  height: 42px;
+  flex: 0 0 auto;
+  border-radius: 8px;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.22);
+}
+
+.brand strong,
+.brand span {
+  display: block;
+  overflow-wrap: anywhere;
+}
+
+.brand strong {
+  font-size: 0.98rem;
+}
+
+.brand span {
+  margin-top: 2px;
+  color: #a8b3bd;
+  font-size: 0.78rem;
+}
+
+.project-nav {
+  display: grid;
+  gap: 8px;
+}
+
+.project-button {
+  display: grid;
+  gap: 3px;
+  width: 100%;
+  min-height: 58px;
+  padding: 11px 12px;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+}
+
+.project-button:hover {
+  background: rgba(255, 255, 255, 0.07);
+}
+
+.project-button.active {
+  border-color: rgba(255, 255, 255, 0.18);
+  background: #f7faf9;
+  color: var(--ink);
+}
+
+.project-button span,
+.project-button small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.project-button span {
+  font-weight: 700;
+}
+
+.project-button small {
+  color: #91a0ab;
+}
+
+.project-button.active small {
+  color: var(--muted);
+}
+
+.sidebar-footer {
+  display: grid;
+  gap: 10px;
+  margin-top: auto;
+}
+
+.source-pill,
+.link-button {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  min-height: 40px;
+  padding: 9px 10px;
+  border: 1px solid rgba(255, 255, 255, 0.13);
+  border-radius: 8px;
+  background: var(--sidebar-soft);
+  color: #eef5f3;
+  font-size: 0.86rem;
+  text-decoration: none;
+}
+
+.link-button {
+  justify-content: space-between;
+}
+
+.link-button span,
+.source-pill span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workspace {
+  min-width: 0;
+  padding: 22px;
+}
+
+.workspace-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  margin-bottom: 18px;
+}
+
+.workspace-title {
+  min-width: 0;
+}
+
+.workspace-title h1 {
+  margin: 0;
+  overflow-wrap: anywhere;
+  font-size: 1.75rem;
+  letter-spacing: 0;
+}
+
+.workspace-title p {
+  margin: 5px 0 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.section-tabs {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-width: min(100%, 420px);
+  padding: 4px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+}
+
+.section-tabs button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  width: 100%;
+  min-height: 36px;
+  padding: 8px 10px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--muted);
+  font-weight: 700;
+}
+
+.section-tabs button.active {
+  background: #26323d;
+  color: #ffffff;
+}
+
+.section-stack {
+  display: grid;
+  gap: 16px;
+}
+
+.metrics-grid {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.metric {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+  min-height: 92px;
+  padding: 16px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  box-shadow: 0 6px 18px rgba(31, 41, 51, 0.05);
+}
+
+.metric > span {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  flex: 0 0 auto;
+  border-radius: 8px;
+  background: #e8f3f1;
+  color: var(--teal);
+}
+
+.metric.warn > span {
+  background: #fff3db;
+  color: var(--gold);
+}
+
+.metric strong,
+.metric small {
+  display: block;
+}
+
+.metric strong {
+  overflow-wrap: anywhere;
+  font-size: 1.35rem;
+}
+
+.metric small {
+  margin-top: 2px;
+  color: var(--muted);
+}
+
+.overview-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.panel,
+.list-panel,
+.detail-panel,
+.audit-main,
+.export-panel,
+.message-detail {
+  min-width: 0;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  box-shadow: 0 8px 26px rgba(31, 41, 51, 0.06);
+}
+
+.panel {
+  padding: 16px;
+}
+
+.panel h2,
+.panel-heading h2 {
+  margin: 0;
+  font-size: 1rem;
+  letter-spacing: 0;
+}
+
+.bar-list,
+.repeat-list,
+.tool-list,
+.token-stack {
+  display: grid;
+  gap: 12px;
+  margin-top: 14px;
+}
+
+.bar-row {
+  display: grid;
+  gap: 7px;
+}
+
+.bar-label {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  font-size: 0.86rem;
+}
+
+.bar-label span,
+.bar-label strong {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bar-label strong {
+  color: var(--muted);
+  font-size: 0.78rem;
+}
+
+.bar-track {
+  height: 9px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #e8ecec;
+}
+
+.bar-track span {
+  display: block;
+  width: var(--bar-width);
+  height: 100%;
+  border-radius: inherit;
+}
+
+.bar-row.teal .bar-track span {
+  background: var(--teal);
+}
+
+.bar-row.blue .bar-track span {
+  background: var(--blue);
+}
+
+.bar-row.gold .bar-track span {
+  background: var(--gold);
+}
+
+.repeat-row {
+  display: grid;
+  gap: 3px;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.repeat-row:last-child {
+  border-bottom: 0;
+}
+
+.repeat-row strong {
+  overflow-wrap: anywhere;
+}
+
+.repeat-row span,
+.empty-state {
+  color: var(--muted);
+  font-size: 0.88rem;
+}
+
+.browser-grid,
+.search-grid,
+.audit-grid {
+  display: grid;
+  grid-template-columns: minmax(300px, 390px) minmax(0, 1fr);
+  gap: 16px;
+  min-height: calc(100vh - 116px);
+}
+
+.list-panel,
+.detail-panel,
+.audit-main,
+.message-detail,
+.export-panel {
+  overflow: hidden;
+}
+
+.panel-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-height: 54px;
+  padding: 15px 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.panel-heading span,
+.result-count {
+  flex: 0 0 auto;
+  color: var(--muted);
+  font-size: 0.84rem;
+  font-weight: 700;
+}
+
+.prompt-list,
+.search-results {
+  display: grid;
+  align-content: start;
+  max-height: calc(100vh - 172px);
+  overflow-y: auto;
+}
+
+.prompt-row,
+.search-row {
+  display: grid;
+  gap: 6px;
+  width: 100%;
+  padding: 14px 16px;
+  border: 0;
+  border-bottom: 1px solid var(--border);
+  background: transparent;
+  color: var(--ink);
+  text-align: left;
+}
+
+.prompt-row:hover,
+.search-row:hover {
+  background: var(--surface-muted);
+}
+
+.prompt-row.active,
+.search-row.active {
+  background: #eaf5f3;
+}
+
+.prompt-row strong,
+.search-row strong {
+  overflow-wrap: anywhere;
+  line-height: 1.35;
+}
+
+.prompt-row span,
+.prompt-row small,
+.search-row small,
+.search-row span {
+  color: var(--muted);
+  font-size: 0.78rem;
+}
+
+.search-row span {
+  width: fit-content;
+  padding: 3px 7px;
+  border-radius: 999px;
+  background: #edf0ef;
+  color: #46515c;
+  font-weight: 700;
+  text-transform: capitalize;
+}
+
+.detail-panel {
+  padding: 18px;
+  overflow-y: auto;
+}
+
+.interaction-detail {
+  display: grid;
+  gap: 16px;
+}
+
+.detail-title {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.detail-title.compact {
+  align-items: center;
+}
+
+.detail-title p {
+  margin: 0 0 5px;
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.detail-title h2 {
+  margin: 0;
+  overflow-wrap: anywhere;
+  font-size: 1.3rem;
+  letter-spacing: 0;
+}
+
+.intent-badge {
+  flex: 0 1 auto;
+  max-width: 220px;
+  padding: 6px 9px;
+  border: 1px solid #d9e6e3;
+  border-radius: 999px;
+  background: #f0faf7;
+  color: var(--teal);
+  font-size: 0.78rem;
+  font-weight: 800;
+  overflow-wrap: anywhere;
+  text-align: center;
+}
+
+.detail-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.detail-meta span {
+  padding: 5px 8px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: #fafafa;
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.response-block {
+  padding: 16px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface-muted);
+}
+
+.response-block.subdued {
+  background: #f7f4ee;
+}
+
+.response-block h3 {
+  margin: 0 0 8px;
+  font-size: 0.88rem;
+}
+
+.response-block p {
+  margin: 0;
+  overflow-wrap: anywhere;
+  color: #34404c;
+  line-height: 1.55;
+}
+
+.detail-columns {
+  display: grid;
+  grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
+  gap: 14px;
+}
+
+.tool-row {
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr);
+  gap: 9px;
+  align-items: start;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.tool-row:last-child {
+  border-bottom: 0;
+}
+
+.tool-row svg {
+  color: var(--blue);
+  margin-top: 2px;
+}
+
+.tool-row strong,
+.tool-row span {
+  display: block;
+  overflow-wrap: anywhere;
+}
+
+.tool-row span {
+  margin-top: 3px;
+  color: var(--muted);
+  font-size: 0.84rem;
+}
+
+.token-total {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding-top: 10px;
+  border-top: 1px solid var(--border);
+}
+
+.token-total span {
+  color: var(--muted);
+}
+
+.search-layout {
+  display: grid;
+  gap: 14px;
+}
+
+.search-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+}
+
+.search-input {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  min-width: 180px;
+  flex: 1 1 auto;
+  min-height: 40px;
+  padding: 0 11px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.search-input svg {
+  color: var(--muted);
+  flex: 0 0 auto;
+}
+
+.search-input input,
+.search-toolbar select {
+  width: 100%;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--ink);
+}
+
+.search-toolbar select {
+  flex: 0 0 150px;
+  min-height: 40px;
+  padding: 0 10px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.message-detail {
+  display: grid;
+  align-content: start;
+  gap: 15px;
+  padding: 18px;
+}
+
+.message-detail pre,
+.markdown-preview {
+  margin: 0;
+  overflow: auto;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: #20252b;
+  color: #f5fbfa;
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-size: 0.86rem;
+  line-height: 1.55;
+  white-space: pre-wrap;
+}
+
+.message-detail pre {
+  max-height: 48vh;
+  padding: 16px;
+}
+
+.audit-grid {
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 360px);
+}
+
+.audit-main {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+}
+
+.markdown-preview {
+  min-height: 520px;
+  max-height: calc(100vh - 182px);
+  border: 0;
+  border-radius: 0;
+  padding: 18px;
+}
+
+.export-panel {
+  display: grid;
+  align-content: start;
+  gap: 16px;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.export-actions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+  margin-top: 14px;
+}
+
+.export-actions button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 40px;
+  border: 1px solid #cfd8d6;
+  border-radius: 8px;
+  background: #26323d;
+  color: #ffffff;
+  font-weight: 800;
+}
+
+.export-facts {
+  display: grid;
+  gap: 6px;
+  margin-top: 16px;
+}
+
+.export-facts span {
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.export-facts strong {
+  overflow-wrap: anywhere;
+  font-size: 0.88rem;
+}
+
+@media (max-width: 1120px) {
+  :root {
+    --site-chrome-height: 218px;
+  }
+
+  .site-nav {
+    align-items: flex-start;
+    flex-direction: column;
+    justify-content: center;
+    gap: 18px;
+    min-height: 132px;
+    padding: 22px 32px;
+  }
+
+  .site-links {
+    flex-wrap: wrap;
+    justify-content: flex-start;
+    gap: 16px 28px;
+  }
+
+  .site-links a {
+    font-size: 1rem;
+  }
+
+  .metrics-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .overview-grid,
+  .detail-columns {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 880px) {
+  .app-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    position: static;
+    height: auto;
+  }
+
+  .project-nav {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .sidebar-footer {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .source-pill {
+    grid-column: 1 / -1;
+  }
+
+  .workspace-header,
+  .search-toolbar,
+  .detail-title {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .section-tabs {
+    min-width: 0;
+    width: 100%;
+  }
+
+  .browser-grid,
+  .search-grid,
+  .audit-grid {
+    grid-template-columns: 1fr;
+    min-height: 0;
+  }
+
+  .prompt-list,
+  .search-results {
+    max-height: 360px;
+  }
+
+  .markdown-preview {
+    max-height: 520px;
+  }
+}
+
+@media (max-width: 620px) {
+  :root {
+    --site-chrome-height: 251px;
+  }
+
+  .site-nav {
+    padding: 20px 18px;
+  }
+
+  .site-brand {
+    min-width: 0;
+    font-size: 1rem;
+    letter-spacing: 0;
+  }
+
+  .site-links {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    width: 100%;
+    gap: 13px 18px;
+  }
+
+  .site-links a {
+    overflow-wrap: anywhere;
+    white-space: normal;
+  }
+
+  .site-network-band {
+    height: 52px;
+  }
+
+  .workspace,
+  .sidebar {
+    padding: 16px;
+  }
+
+  .metrics-grid,
+  .project-nav,
+  .sidebar-footer,
+  .section-tabs {
+    grid-template-columns: 1fr;
+  }
+
+  .section-tabs {
+    display: grid;
+  }
+
+  .metrics-grid,
+  .overview-grid {
+    gap: 10px;
+  }
+
+  .search-toolbar select {
+    flex-basis: auto;
+    width: 100%;
+  }
+
+  .intent-badge {
+    max-width: none;
+  }
+}

--- a/apps/web-demo/src/types.ts
+++ b/apps/web-demo/src/types.ts
@@ -1,0 +1,224 @@
+export interface TokenUsage {
+  inputTokens: number;
+  cachedInputTokens: number;
+  freshInputTokens: number;
+  outputTokens: number;
+  reasoningOutputTokens: number;
+  totalTokens: number;
+}
+
+export interface DateBucket {
+  key: string;
+  count: number;
+  uniqueCount: number;
+  tokens: TokenUsage;
+}
+
+export interface ModelBucket {
+  model: string;
+  turns: number;
+  tokens: TokenUsage;
+}
+
+export interface ProjectListItem {
+  project: string;
+  cwdSamples: string[];
+  sessions: number;
+  turns: number;
+  messages: number;
+  totalTokens: number;
+  firstSeen?: string;
+  lastSeen?: string;
+}
+
+export interface SessionSummary {
+  sessionId: string;
+  filePath: string;
+  dateKey: string;
+  project: string;
+  cwd?: string;
+  firstSeen?: string;
+  lastSeen?: string;
+  userMessages: number;
+  automationMessages: number;
+  assistantMessages: number;
+  totalTokens: number;
+  models: string[];
+}
+
+export interface PromptIntentBucket {
+  key: string;
+  label: string;
+  count: number;
+  percentage: number;
+  sessionCount: number;
+  projects: string[];
+  examples: string[];
+  firstSeen?: string;
+  lastSeen?: string;
+}
+
+export interface PromptIntentSummary {
+  totalMessages: number;
+  classifiedMessages: number;
+  unclassifiedMessages: number;
+  buckets: PromptIntentBucket[];
+}
+
+export interface RepeatedUserMessage {
+  id: string;
+  sample: string;
+  category?: string;
+  count: number;
+  sessionCount: number;
+  projects: string[];
+  firstSeen?: string;
+  lastSeen?: string;
+  variants: Array<{
+    sample: string;
+    count: number;
+    firstSeen?: string;
+    lastSeen?: string;
+  }>;
+}
+
+export interface ProjectSummary {
+  project: string;
+  generatedAt: string;
+  activity: {
+    firstSeen?: string;
+    lastSeen?: string;
+  };
+  filters: {
+    since?: string;
+    until?: string;
+    paths: string[];
+  };
+  totals: {
+    sessions: number;
+    turns: number;
+    userMessages: number;
+    automationMessages: number;
+    assistantMessages: number;
+    uniqueUserMessages: number;
+    toolEvents: number;
+    unknownEvents: number;
+    parseWarnings: number;
+  };
+  tokens: TokenUsage;
+  messagesByDay: DateBucket[];
+  messagesByHour: DateBucket[];
+  tokensByDay: DateBucket[];
+  models: ModelBucket[];
+  sessions: SessionSummary[];
+  promptIntents: PromptIntentSummary;
+  repeatedUserMessages: RepeatedUserMessage[];
+}
+
+export type MessageRole = "user" | "assistant" | "system" | "developer" | "automation" | "unknown";
+
+export interface MessageSearchResult {
+  id: string;
+  sessionId: string;
+  filePath: string;
+  dateKey: string;
+  project: string;
+  cwd?: string;
+  lineNumber?: number;
+  turnId?: string;
+  model?: string;
+  timestamp?: string;
+  role: MessageRole;
+  sourceEvent: string;
+  category?: string;
+  promptIntentKey?: string;
+  promptIntent?: string;
+  snippet: string;
+  content: string;
+}
+
+export interface ToolEvent {
+  filePath: string;
+  sessionId: string;
+  lineNumber?: number;
+  turnId?: string;
+  timestamp?: string;
+  eventType: string;
+  name?: string;
+  callId?: string;
+  content?: string;
+  cwd?: string;
+  exitCode?: number;
+  durationMs?: number;
+}
+
+export interface DemoInteraction {
+  id: string;
+  sessionId: string;
+  filePath: string;
+  turnId?: string;
+  timestamp?: string;
+  userMessage: string;
+  assistantMessage: string;
+  model: string;
+  effort?: string;
+  promptIntentKey: string;
+  promptIntent: string;
+  category?: string;
+  tokenUsage?: TokenUsage;
+  durationMs?: number;
+  timeToFirstTokenMs?: number;
+  tools: ToolEvent[];
+  contextMessages: string[];
+}
+
+export interface SessionDetail {
+  id: string;
+  sessionId: string;
+  filePath: string;
+  project: string;
+  cwd?: string;
+  firstSeen?: string;
+  lastSeen?: string;
+  lineCount: number;
+  turns: unknown[];
+  messages: unknown[];
+  tokenUsage: unknown[];
+  taskTimings: unknown[];
+  toolEvents: ToolEvent[];
+  unknownEvents: unknown[];
+  warnings: unknown[];
+  interactions: DemoInteraction[];
+}
+
+export interface DemoData {
+  schemaVersion: number;
+  generatedAt: string;
+  source: {
+    kind: string;
+    fixturePath: string;
+    privacy: string;
+    profiles: Array<{
+      project: string;
+      promptCount: number;
+      basis: string;
+    }>;
+  };
+  links: {
+    repository: string;
+    releases: string;
+    privacyDocs: string;
+  };
+  projects: ProjectListItem[];
+  projectNames: string[];
+  summaries: Record<string, ProjectSummary>;
+  messages: MessageSearchResult[];
+  submittedMessages: MessageSearchResult[];
+  sessionDetails: SessionDetail[];
+  auditPreview: {
+    targetPath: string;
+    generatedMarkdown: string;
+    appendedSections: number;
+    skippedSections: number;
+  };
+}

--- a/apps/web-demo/src/vite-env.d.ts
+++ b/apps/web-demo/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/apps/web-demo/tsconfig.json
+++ b/apps/web-demo/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "types": ["vite/client"],
+    "allowSyntheticDefaultImports": true,
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": false,
+    "noEmit": true
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/apps/web-demo/vite.config.ts
+++ b/apps/web-demo/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  base: "./",
+  plugins: [react()],
+  build: {
+    chunkSizeWarningLimit: 6_000
+  }
+});

--- a/docs/ai-worklog.md
+++ b/docs/ai-worklog.md
@@ -2,6 +2,84 @@
 
 Sanitized audit trail of AI-assisted work on this project.
 
+## 2026-06-07 - Align Web Demo With Native Overview
+
+Status: Completed
+Related commit/PR: TBD
+
+### User Messages
+
+> The web simulation you created does not match the user interface of the real app
+
+### Interpreted Intent
+
+The user wanted the static web demo to visually match the native macOS app Overview instead of presenting a chart-heavy simulation that drifted away from the real product interface.
+
+### Response / Work Done
+
+- Changed the web demo to open on the Overview section by default.
+- Matched the native Overview order: workspace header, date range control, segmented tabs, metric tiles, Project Focus, then charts below.
+- Added the native-style Project Focus donut chart, top-category pill, category rows, session/example metadata, and show-all-category toggle.
+- Retuned the web demo to the dark macOS grouped-panel visual language shown in the real app screenshot.
+- Made the public simulation workspace-first so it starts at the `All Projects` view rather than showing a separate web sidebar.
+- Fixed narrow viewport layout so Project Focus stacks cleanly without horizontal overflow.
+
+### Privacy Notes
+
+No raw Codex logs, private prompts, private project names, screenshots, recordings, export payloads, credentials, secrets, or local session paths were added. The demo remains synthetic.
+
+### Verification
+
+- Ran `npm run build:web-demo`.
+- Ran `npm run check:web-demo-privacy`.
+- Ran `git diff --check`.
+- Verified the local web demo in the in-app browser at desktop and mobile widths, including no console errors and no horizontal overflow on mobile.
+
+## 2026-06-07 - Fix Large Cache Parser Failure
+
+Status: Completed
+Related commit/PR: TBD
+
+### User Messages
+
+> Launch my local app
+
+> Why am I getting this error code?
+
+> Please fix this issue -- You need to be able to handle a large cash
+
+### Interpreted Intent
+
+The user wanted the local macOS app launched, then wanted the launch-time parser `HTTP 500` diagnosed and fixed so very large local Codex log caches can be parsed without crashing.
+
+### Response / Work Done
+
+- Reproduced the local parser failure and traced it to parsed-cache serialization of a very large newly discovered session.
+- Identified image-generation log payloads as the immediate trigger: generated image result data was being preserved inside unknown-event raw payloads.
+- Added bounded unknown-event raw previews so future unsupported event shapes cannot duplicate huge binary or image payloads into the parsed cache.
+- Treated image-generation call and completion records as normalized tool events while omitting generated image data from normalized records.
+- Added parser and cache regression tests using sanitized synthetic data.
+- Updated parser schema notes to document bounded unknown-event previews and image-generation event handling.
+- Rebuilt and repackaged the native macOS app so the bundled local parser engine includes the fix.
+
+### Privacy Notes
+
+No raw Codex logs, private prompts, generated image data, session contents, screenshots, recordings, export payloads, credentials, secrets, or local session paths were added. Investigation used aggregate counts and sanitized event-shape metadata only.
+
+### Verification
+
+- Ran `wt bootstrap`.
+- Ran `npm run build -w @codex-log-viewer/parser`.
+- Ran `node --test packages/parser/test/parser.test.mjs packages/parser/test/cache.test.mjs`.
+- Ran a local aggregate-only corpus load against the app cache and confirmed it completed without `Invalid string length`.
+- Ran a direct `/api/projects` endpoint check against the app cache and confirmed `HTTP 200`.
+- Ran `npm test`.
+- Ran `npm run lint`.
+- Ran `npm run package:mac`.
+- Ran `npm run smoke:mac-ui`.
+- Ran `npm run smoke:mac-package` after cleaning up the earlier app instance.
+- Ran `npm run privacy:scan`.
+
 ## 2026-06-07 - Build Static Synthetic Web Demo
 
 Status: Completed

--- a/docs/ai-worklog.md
+++ b/docs/ai-worklog.md
@@ -2,6 +2,250 @@
 
 Sanitized audit trail of AI-assisted work on this project.
 
+## 2026-06-07 - Build Static Synthetic Web Demo
+
+Status: Completed
+Related commit/PR: TBD
+
+### User Messages
+
+> PLEASE IMPLEMENT THIS PLAN:
+> # Synthetic Web Demo For Codex Log Viewer
+>
+> ## Summary
+>
+> Build a standalone static website demo for Codex Log Viewer and link it to the GitHub repository/releases for the real native macOS app.
+>
+> Recommendation: do **not** host the real app as a web service for v1. The current product is intentionally native/local-first, with a SwiftUI UI and a private loopback parser engine. A hosted “real app” would require a new browser app plus a new privacy model for user log files.
+>
+> Effort estimate:
+> - Synthetic static demo: ~3-5 focused days for a polished project-ready version.
+> - Fully functioning real browser app: likely multi-week work because logs cannot be read from a hosted site without upload or browser file import.
+>
+> ## Key Changes
+>
+> - Add a new standalone static web app, likely `apps/web-demo`, using Vite + React + TypeScript.
+> - Create a richer synthetic showcase dataset that represents the real product: multiple projects, sessions, messages, model/token usage, repeated prompts, search results, tool activity, parse warnings, and audit-preview content.
+> - Generate static demo JSON at build time from the existing parser/analytics pipeline, so the public demo is fixture-driven without exposing real logs.
+> - Build a web-native version of the core app experience:
+>   - project sidebar
+>   - Overview metrics and charts
+>   - Browse flow with sent prompts and interaction detail
+>   - Search with filters
+>   - Audit/export preview using synthetic content
+>   - visible links to GitHub repo and GitHub Releases/downloads
+> - Keep the hosted demo static: no backend, no uploads, no telemetry, no real Codex log ingestion.
+>
+> ## Public Interfaces
+>
+> - Add a demo data artifact/schema consumed by the web app, generated from synthetic fixtures.
+> - Add root scripts such as `build:web-demo`, `dev:web-demo`, and possibly `preview:web-demo`.
+> - Add deployment docs for a static host, with GitHub Pages as the default target unless a different host is chosen later.
+> - Do not change the local macOS app API contract or expose the private local server publicly.
+>
+> ## Test Plan
+>
+> - Run existing checks: `npm run privacy:scan`, `npm test`, and `npm run build`.
+> - Add/verify a demo-data generation check so synthetic fixtures produce stable summaries.
+> - Build the static demo and open it locally for visual QA.
+> - Verify responsive layouts on desktop and mobile widths.
+> - Confirm all public links work: GitHub repository, releases/download path, and project docs.
+> - Confirm no real local paths, real session logs, secrets, or private screenshots are committed.
+>
+> ## Assumptions
+>
+> - “Full demo” means a complete interactive showcase of the primary user workflows, not running the SwiftUI app in the browser.
+> - The public demo uses only synthetic data.
+> - The native macOS app remains the real downloadable product.
+> - Website deployment starts as a standalone static app that can later be linked or embedded from your personal site.
+> - Implementation should update `docs/ai-worklog.md` before finishing, per repo instructions.
+
+### Interpreted Intent
+
+The user wanted the planning output implemented as a public-safe standalone static demo that showcases the app experience with synthetic data and points users to the real native macOS app on GitHub.
+
+### Response / Work Done
+
+- Added `apps/web-demo`, a Vite React TypeScript static app with Overview, Browse, Search, Audit preview, synthetic JSON/CSV exports, and GitHub repository/release links.
+- Added `scripts/generate-web-demo-data.mjs` to generate temporary synthetic Codex JSONL, parse it with the existing parser and analytics packages, and generate deterministic browser data.
+- Added root scripts for `demo:data`, `check:web-demo-data`, `dev:web-demo`, `build:web-demo`, and `preview:web-demo`.
+- Added static web demo documentation and updated the README.
+
+### Privacy Notes
+
+No raw Codex logs, private screenshots, local exports, secrets, or unsanitized user session data were added. The demo data uses synthetic prompts and `/Users/example/...` paths only.
+
+### Verification
+
+- Ran `wt bootstrap`.
+- Ran `npm run check:web-demo-data`.
+- Ran `npm test`.
+- Ran `npm run build`.
+- Ran `npm run build:web-demo`.
+- Ran `npm run typecheck -w @codex-log-viewer/web-demo`.
+- Verified the local preview URL returned the built app.
+- Verified the web demo in the in-app browser at desktop width.
+- Verified mobile-width layout had no horizontal overflow, switched to Browse, and searched synthetic messages for `checkout`.
+- Confirmed the GitHub repository, releases, and privacy-doc links returned HTTP 200.
+- Ran `npm run privacy:scan`.
+
+## 2026-06-07 - Expand Web Demo Project Profiles
+
+Status: Completed
+Related commit/PR: TBD
+
+### User Messages
+
+> Actually I think it is better not to expose any of them but I want you, for example, to take a look at:
+> - [redacted website project]
+> - [redacted presentation project]
+> - [redacted photographer guide project]
+>
+> And I want you to add those with synthetic data so have those three. Rename them. By the way now call one a third-party website, call one a presentation, and the last one a photographer's guide
+>
+> Add synthetic data. Look at the real data and just synthesize it. I want these projects to have between 200 and 300 prompts each. I also want you to look at the Codex Log Viewer and expose the data we have. For the Codex Log Viewer you can put the real data
+
+### Interpreted Intent
+
+The user wanted the web demo to avoid exposing private project names while reflecting the shape of three real local project histories as renamed public-safe synthetic projects, plus a Codex Log Viewer profile based on real aggregate proportions.
+
+### Response / Work Done
+
+- Replaced the small hand-written web demo fixtures with deterministic generated synthetic JSONL profiles.
+- Added four public demo projects: `Third-Party Website`, `Executive Presentation`, `Photographer's Guide`, and `Codex Log Viewer`.
+- Generated 250, 260, 240, and 300 prompts respectively, based on aggregate project shape and prompt-intent distributions.
+- Kept raw prompt and response text synthetic, including for Codex Log Viewer, while using Codex Log Viewer aggregate proportions for the public profile.
+- Removed tracked web-demo JSONL fixture files and updated docs to describe generated temporary JSONL instead.
+- Refreshed the open web demo and verified the private source names no longer appear.
+
+### Privacy Notes
+
+The tracked demo does not include raw local Codex logs, private project names, private local paths, or real user prompt/assistant transcript text. The Codex Log Viewer profile uses real aggregate proportions, not raw messages.
+
+### Verification
+
+- Ran local summaries for the private source projects and Codex Log Viewer at aggregate level only.
+- Ran `npm run demo:data`.
+- Ran `npm run check:web-demo-data`.
+- Ran `npm run build:web-demo`.
+- Ran `npm run typecheck -w @codex-log-viewer/web-demo`.
+- Ran `npm test`.
+- Ran `npm run build`.
+- Ran `npm run privacy:scan`.
+- Verified the in-app browser shows only the public project names and 240-300 prompts per public project.
+
+## 2026-06-07 - Audit Web Demo Data For Shareability
+
+Status: Completed
+Related commit/PR: TBD
+
+### User Messages
+
+> Now I want you to go through all the Codex log viewer data and make sure that there are no secret keys, no personal identifiable information, and that the data can actually be shared. If you find any concerning part of the data, like passwords or API keys or anything like that, please redact it
+
+### Interpreted Intent
+
+The user wanted a privacy review of the shareable Codex Log Viewer web-demo data before publication, with redaction or removal of secrets, PII, private paths, and private project names if found.
+
+### Response / Work Done
+
+- Scanned the generated web-demo data for token-like values, private keys, secret assignments, emails, phone-like numbers, private project names, and non-example macOS home paths.
+- Scanned the local Codex Log Viewer source logs at rule/count level only; raw logs contain non-example local home paths, so they remain unsuitable for direct sharing.
+- Confirmed the public demo data uses synthetic prompts/responses and `/Users/example/...` paths.
+- Added `scripts/check-web-demo-privacy.mjs` and the `npm run check:web-demo-privacy` script to enforce the shareability rules on the generated data, generator, and demo docs.
+- Tightened a false-positive scanner rule and renamed an internal generator variable so token metrics are not confused with secret assignments.
+
+### Privacy Notes
+
+No raw local Codex messages, secrets, private paths, or private project names were added. The public demo remains shareable because raw local logs are not exported into it; only synthetic content and public-safe aggregate-shaped data are present.
+
+### Verification
+
+- Ran custom generated-data secret/PII scan.
+- Ran local Codex Log Viewer source-log scan at aggregate finding-count level.
+- Ran `npm run check:web-demo-privacy`.
+- Ran `npm run check:web-demo-data`.
+- Ran `npm run build:web-demo`.
+- Ran `npm run typecheck -w @codex-log-viewer/web-demo`.
+- Ran `npm run privacy:scan`.
+
+## 2026-06-07 - Fit Web Demo Into Personal Site Navigation
+
+Status: Completed
+Related commit/PR: TBD
+
+### User Messages
+
+> Note that this landing page is also going to exist inside my personal website under
+>
+> crispierry.com/projects/codex-log-viewer
+>
+> Remember that you must allow for my website's default navigational links
+
+### Interpreted Intent
+
+The user wanted the Codex Log Viewer project demo to fit naturally under the personal website route, with the default Cristiano Pierry site navigation preserved above the demo experience.
+
+### Response / Work Done
+
+- Added a personal-site header to the standalone web demo with the Cristiano Pierry brand treatment, default top navigation, and light network band visible before the app UI.
+- Verified the current public site navigation destinations and aligned the demo links to `/ask`, `/writing`, `/posts`, `/projects`, and `/photography`.
+- Adjusted the demo shell height and responsive header behavior so the app starts below the site navigation on desktop and mobile.
+
+### Privacy Notes
+
+No Codex logs, private project data, screenshot files, secrets, or personal session content were added. The change is limited to public navigation chrome and layout styling.
+
+### Verification
+
+- Ran `npm run build:web-demo`.
+- Ran `npm run typecheck -w @codex-log-viewer/web-demo`.
+- Ran `npm run check:web-demo-privacy`.
+- Ran `npm run privacy:scan`.
+- Ran `git diff --check`.
+- Verified the in-app browser at desktop width shows the site brand, default navigation links, project demo content, and no private source project names.
+- Verified the in-app browser at mobile width has no horizontal overflow and starts the app below the site header.
+
+## 2026-06-07 - Review And Harden Web Demo
+
+Status: Completed
+Related commit/PR: TBD
+
+### User Messages
+
+> Do a code review and fix any issues found
+
+### Interpreted Intent
+
+The user wanted a reviewer-style pass over the current web-demo implementation, with concrete issues fixed directly instead of only reported.
+
+### Response / Work Done
+
+- Removed production source maps from the web-demo build so the static publish artifact is smaller and does not ship unnecessary source-map files.
+- Fixed frontend guideline issues by removing nonzero letter spacing and replacing viewport-scaled heading type with fixed responsive sizing.
+- Added explicit tab semantics for the Overview, Browse, Search, and Audit section switcher.
+- Added accessible names for the search input and role filter.
+- Made synthetic JSON/CSV export downloads more reliable by attaching the temporary download link before clicking and revoking the object URL after the browser has started the download.
+- Updated the demo data TypeScript shape so `source.profiles` matches the generated JSON schema.
+- Expanded the web-demo privacy check to include the web app source files, not only generated data and docs.
+- Corrected stale worklog wording about generated temporary JSONL and documented the intended `crispierry.com/projects/codex-log-viewer` placement.
+
+### Privacy Notes
+
+No raw Codex logs, private prompts, private project names, screenshots, secrets, or local session files were added. The stricter web-demo privacy check now scans eight web-demo files.
+
+### Verification
+
+- Ran `npm run check:web-demo-data`.
+- Ran `npm run typecheck -w @codex-log-viewer/web-demo`.
+- Ran `npm run check:web-demo-privacy`.
+- Ran `npm run build:web-demo`.
+- Ran `npm run lint`.
+- Ran `npm test`.
+- Ran `npm run privacy:scan`.
+- Ran `git diff --check`.
+- Verified the in-app browser at desktop and mobile widths, including nav links, tab semantics, project list, no private source names, and no horizontal overflow.
+
 ## 2026-05-31 - Resolve Provider PR Merge Conflicts
 
 Status: Completed

--- a/docs/ai-worklog.md
+++ b/docs/ai-worklog.md
@@ -2,6 +2,35 @@
 
 Sanitized audit trail of AI-assisted work on this project.
 
+## 2026-06-07 - Fix PR Version Check Failure
+
+Status: Completed
+Related commit/PR: PR #21
+
+### User Messages
+
+> I'm getting a git error. Can you check what it is and why it's failing?
+
+> Please fix it
+
+### Interpreted Intent
+
+The user wanted the failing GitHub/CI condition on the pushed PR diagnosed and corrected so the branch can pass the required checks.
+
+### Response / Work Done
+
+- Inspected PR #21 status and identified the failing `verify` job.
+- Confirmed the failure was the required PR app-version bump: `main` was `0.2.8`, while the branch was only `0.2.9`.
+- Ran the repository version bump workflow to update the app version metadata to `0.3.0`.
+
+### Privacy Notes
+
+No raw Codex logs, private prompts, session contents, screenshots, recordings, export payloads, credentials, secrets, or local session paths were added.
+
+### Verification
+
+- Ran `node scripts/check-app-version.mjs --compare-ref origin/main --require-pr-minor`.
+
 ## 2026-06-07 - Align Web Demo With Native Overview
 
 Status: Completed

--- a/docs/parser-schema-notes.md
+++ b/docs/parser-schema-notes.md
@@ -198,7 +198,8 @@ Cursor's public docs describe regular Agent chat history as local SQLite data an
 - Aggregate per-turn tokens from `last_token_usage` when present.
 - Use cumulative `total_token_usage` for reconciliation, not as the primary sum.
 - Ignore token usage for `token_count` events with `info: null`.
-- Preserve unknown events and include counts in parser summaries.
+- Preserve unknown event metadata and include counts in parser summaries. Bound raw unknown-event previews so large binary/image payloads cannot overwhelm local caches.
+- Treat image-generation call and completion payloads as tool events while omitting generated image data from normalized records.
 - Use normalized line numbers and turn ids to reconstruct the AI interaction that follows a selected submitted user message.
 
 ## Schema Change Policy

--- a/docs/web-demo.md
+++ b/docs/web-demo.md
@@ -8,7 +8,7 @@ The static web demo is a public-safe project showcase for Codex Log Viewer. It i
 - The generator writes temporary synthetic JSONL, parses it with the existing parser and analytics packages, then removes the temporary files.
 - Generated browser data is written to `apps/web-demo/src/data/demo-data.generated.json`.
 - `apps/web-demo` is a Vite React app that ships as static files with relative asset URLs.
-- The standalone page is designed to fit under `crispierry.com/projects/codex-log-viewer` and preserves the personal website navigation links above the demo experience.
+- The standalone page is chrome-free and iframe-ready. The real `crispierry.com/projects/codex-log-viewer` route supplies the personal website navigation above the demo experience.
 
 ## Commands
 
@@ -30,6 +30,14 @@ npm run build:web-demo
 ```
 
 Publish the contents of `apps/web-demo/dist/`.
+
+For the personal website, publish from the website repo with:
+
+```sh
+npm run build:codex-log-viewer
+```
+
+That command builds this source demo and refreshes `public/project-apps/codex-log-viewer/` in the website repo.
 
 ## Privacy
 

--- a/docs/web-demo.md
+++ b/docs/web-demo.md
@@ -1,0 +1,36 @@
+# Static Web Demo
+
+The static web demo is a public-safe project showcase for Codex Log Viewer. It is not the real hosted app; the native macOS app remains the product that reads local Codex logs.
+
+## Shape
+
+- Public project profiles live in `scripts/generate-web-demo-data.mjs`.
+- The generator writes temporary synthetic JSONL, parses it with the existing parser and analytics packages, then removes the temporary files.
+- Generated browser data is written to `apps/web-demo/src/data/demo-data.generated.json`.
+- `apps/web-demo` is a Vite React app that ships as static files with relative asset URLs.
+- The standalone page is designed to fit under `crispierry.com/projects/codex-log-viewer` and preserves the personal website navigation links above the demo experience.
+
+## Commands
+
+```sh
+npm run demo:data
+npm run check:web-demo-data
+npm run check:web-demo-privacy
+npm run dev:web-demo
+npm run build:web-demo
+npm run preview:web-demo
+```
+
+## Deployment
+
+The default deployment target is any static host. GitHub Pages works because the Vite build uses relative asset paths:
+
+```sh
+npm run build:web-demo
+```
+
+Publish the contents of `apps/web-demo/dist/`.
+
+## Privacy
+
+The demo uses synthetic prompts and responses, with public-safe project names. Codex Log Viewer can use real aggregate proportions, but raw local messages, private source project names, local exports, and private screenshots must not be added to generated browser data.

--- a/fixtures/codex/event-shapes.jsonl
+++ b/fixtures/codex/event-shapes.jsonl
@@ -14,6 +14,8 @@
 {"timestamp":"2026-04-28T10:00:11.000Z","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"call-2"}}
 {"timestamp":"2026-04-28T10:00:12.000Z","type":"event_msg","payload":{"type":"exec_command_end","cwd":"/Users/example/projects/shape-app","exit_code":0,"duration":{"millis":42}}}
 {"timestamp":"2026-04-28T10:00:13.000Z","type":"event_msg","payload":{"type":"patch_apply_end","duration":{"millis":25}}}
+{"timestamp":"2026-04-28T10:00:13.250Z","type":"response_item","payload":{"type":"image_generation_call","id":"image-call-1","status":"completed","revised_prompt":"Sanitized prompt for a generated test image.","result":"redacted-base64-image-data"}}
+{"timestamp":"2026-04-28T10:00:13.500Z","type":"event_msg","payload":{"type":"image_generation_end","call_id":"image-call-1","status":"completed","revised_prompt":"Sanitized prompt for a generated test image.","result":"redacted-base64-image-data","saved_path":"/Users/example/Desktop/redacted.png"}}
 {"timestamp":"2026-04-28T10:00:14.000Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"shape-turn-1","completed_at":1777399214000,"duration_ms":12000,"time_to_first_token_ms":700,"last_agent_message":"Done."}}
 {"timestamp":"2026-04-28T10:00:15.000Z","type":"event_msg","payload":{"type":"future_payload","value":"preserved"}}
 {"timestamp":"2026-04-28T10:00:16.000Z","type":"future_top_level","payload":{"type":"future_payload","value":"preserved"}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-log-viewer",
-  "version": "0.2.9",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-log-viewer",
-      "version": "0.2.9",
+      "version": "0.3.0",
       "license": "MIT",
       "workspaces": [
         "packages/*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-log-viewer",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-log-viewer",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "license": "MIT",
       "workspaces": [
         "packages/*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "workspaces": [
         "packages/*",
         "apps/cli",
-        "apps/server"
+        "apps/server",
+        "apps/web-demo"
       ],
       "devDependencies": {
         "@types/node": "^24.0.0",
@@ -42,6 +43,21 @@
         "@codex-log-viewer/parser": "0.1.0"
       }
     },
+    "apps/web-demo": {
+      "name": "@codex-log-viewer/web-demo",
+      "version": "0.1.0",
+      "dependencies": {
+        "lucide-react": "^1.17.0",
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7"
+      },
+      "devDependencies": {
+        "@types/react": "^19.2.17",
+        "@types/react-dom": "^19.2.3",
+        "@vitejs/plugin-react": "^6.0.2",
+        "vite": "^8.0.16"
+      }
+    },
     "node_modules/@codex-log-viewer/analytics": {
       "resolved": "packages/analytics",
       "link": true
@@ -58,6 +74,366 @@
       "resolved": "apps/server",
       "link": true
     },
+    "node_modules/@codex-log-viewer/web-demo": {
+      "resolved": "apps/web-demo",
+      "link": true
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@types/node": {
       "version": "24.12.2",
       "dev": true,
@@ -65,6 +441,548 @@
       "dependencies": {
         "undici-types": "~7.16.0"
       }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.2.tgz",
+      "integrity": "sha512-DlSMqo4WhThw4vB8Mpn0Woe9J+Jfq1geJ61AKW0QEgLzGMNwtIMdxbDUzLxcun8W7NbJO0e2Jg/Nxm3cCSVzzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rolldown/plugin-babel": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.17.0.tgz",
+      "integrity": "sha512-9FA9evdox/JQL5PT57fdA1x/yg8T7knJ98+zjTL3UfKza6pflQUUh3XtaQIHKvnsJw1lmsEyHVlt5jchYxOQ5w==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.7"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/typescript": {
       "version": "5.9.3",
@@ -82,6 +1000,84 @@
       "version": "7.16.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
     },
     "packages/analytics": {
       "name": "@codex-log-viewer/analytics",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-log-viewer",
-  "version": "0.2.9",
+  "version": "0.3.0",
   "private": true,
   "description": "Local-first native macOS app and parser for OpenAI Codex session logs.",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-log-viewer",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "private": true,
   "description": "Local-first native macOS app and parser for OpenAI Codex session logs.",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   "workspaces": [
     "packages/*",
     "apps/cli",
-    "apps/server"
+    "apps/server",
+    "apps/web-demo"
   ],
   "scripts": {
     "build": "npm run build -w @codex-log-viewer/parser && npm run build -w @codex-log-viewer/analytics && npm run build -w @codex-log-viewer/server && npm run build -w @codex-log-viewer/cli",
@@ -46,6 +47,12 @@
     "check:mac-accessibility": "node scripts/check-native-accessibility.mjs",
     "benchmark:search": "npm run build -w @codex-log-viewer/parser && npm run build -w @codex-log-viewer/analytics && node scripts/benchmark-search.mjs",
     "check:reference": "npm run build -w @codex-log-viewer/parser && npm run build -w @codex-log-viewer/analytics && node scripts/check-reference-report.mjs",
+    "demo:data": "npm run build -w @codex-log-viewer/parser && npm run build -w @codex-log-viewer/analytics && node scripts/generate-web-demo-data.mjs",
+    "check:web-demo-data": "npm run build -w @codex-log-viewer/parser && npm run build -w @codex-log-viewer/analytics && node scripts/generate-web-demo-data.mjs --check",
+    "check:web-demo-privacy": "node scripts/check-web-demo-privacy.mjs",
+    "build:web-demo": "npm run build -w @codex-log-viewer/web-demo",
+    "dev:web-demo": "npm run dev -w @codex-log-viewer/web-demo",
+    "preview:web-demo": "npm run preview -w @codex-log-viewer/web-demo",
     "app:mac": "npm run build:native-engine && npm run version:sync && CODEX_LOG_VIEWER_REPO=$PWD swift run --package-path apps/macos CodexLogViewerMac",
     "desktop": "npm run app:mac",
     "desktop:dev": "npm run app:mac",

--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -73,6 +73,8 @@ const KNOWN_PAYLOAD_TYPES = new Set([
   "exec_command_end",
   "function_call",
   "function_call_output",
+  "image_generation_call",
+  "image_generation_end",
   "message",
   "patch_apply_end",
   "reasoning",
@@ -94,6 +96,10 @@ const CLAUDE_KNOWN_RECORD_TYPES = new Set([
 ]);
 
 const USER_REQUEST_MARKER = "## My request for Codex:";
+const MAX_UNKNOWN_RAW_STRING_LENGTH = 4_096;
+const MAX_UNKNOWN_RAW_ARRAY_ITEMS = 20;
+const MAX_UNKNOWN_RAW_OBJECT_KEYS = 50;
+const MAX_UNKNOWN_RAW_DEPTH = 6;
 
 export async function parseCodexCorpus(options: ParseOptions = {}): Promise<ParsedCodexCorpus> {
   const files = await discoverCodexLogFiles(options.paths);
@@ -625,7 +631,7 @@ function classifyCodexEvent(context: ClassifyContext): void {
       timestamp,
       eventType: payloadType ?? topLevelType ?? "unknown_tool_event",
       name: stringValue(payload.name),
-      callId: stringValue(payload.call_id),
+      callId: stringValue(payload.call_id) ?? stringValue(payload.id),
       content: toolEventContent(payload),
       cwd: stringValue(payload.cwd),
       exitCode: numberValue(payload.exit_code),
@@ -796,6 +802,7 @@ function addUnknown(
   topLevelType?: string,
   payloadType?: string
 ): void {
+  const raw = boundedUnknownRaw(context.raw);
   context.unknownEvents.push({
     provider: context.state.provider,
     inputKind: context.state.inputKind,
@@ -808,7 +815,8 @@ function addUnknown(
     timestamp,
     topLevelType,
     payloadType,
-    raw: context.raw
+    rawTruncated: raw.truncated ? true : undefined,
+    raw: raw.value
   });
 }
 
@@ -1230,8 +1238,9 @@ function isToolEvent(topLevelType?: string, payloadType?: string): boolean {
     (payloadType === "function_call" ||
       payloadType === "function_call_output" ||
       payloadType === "custom_tool_call" ||
-      payloadType === "custom_tool_call_output")
-  ) || payloadType === "exec_command_end" || payloadType === "patch_apply_end";
+      payloadType === "custom_tool_call_output" ||
+      payloadType === "image_generation_call")
+  ) || payloadType === "exec_command_end" || payloadType === "patch_apply_end" || payloadType === "image_generation_end";
 }
 
 function sessionIdFromFile(filePath: string): string {
@@ -1486,4 +1495,79 @@ function numberValue(value: unknown): number | undefined {
 
 function arrayValue(value: unknown): unknown[] {
   return Array.isArray(value) ? value : [];
+}
+
+function boundedUnknownRaw(value: JsonObject): { value: JsonObject; truncated: boolean } {
+  const bounded = boundJsonValue(value, 0);
+  return {
+    value: isObject(bounded.value) ? bounded.value : {},
+    truncated: bounded.truncated
+  };
+}
+
+function boundJsonValue(value: unknown, depth: number): { value: unknown; truncated: boolean } {
+  if (typeof value === "string") {
+    if (value.length <= MAX_UNKNOWN_RAW_STRING_LENGTH) {
+      return { value, truncated: false };
+    }
+    return {
+      value: {
+        truncated: true,
+        type: "string",
+        length: value.length
+      },
+      truncated: true
+    };
+  }
+
+  if (Array.isArray(value)) {
+    let truncated = false;
+    const items = value.slice(0, MAX_UNKNOWN_RAW_ARRAY_ITEMS).map((item) => {
+      const bounded = boundJsonValue(item, depth + 1);
+      truncated = truncated || bounded.truncated;
+      return bounded.value;
+    });
+    if (value.length > MAX_UNKNOWN_RAW_ARRAY_ITEMS) {
+      items.push({
+        truncated: true,
+        type: "array",
+        remainingItems: value.length - MAX_UNKNOWN_RAW_ARRAY_ITEMS
+      });
+      truncated = true;
+    }
+    return { value: items, truncated };
+  }
+
+  if (isObject(value)) {
+    if (depth >= MAX_UNKNOWN_RAW_DEPTH) {
+      return {
+        value: {
+          truncated: true,
+          type: "object",
+          keys: Object.keys(value).length
+        },
+        truncated: true
+      };
+    }
+
+    let truncated = false;
+    const entries = Object.entries(value);
+    const output: JsonObject = {};
+    for (const [key, child] of entries.slice(0, MAX_UNKNOWN_RAW_OBJECT_KEYS)) {
+      const bounded = boundJsonValue(child, depth + 1);
+      output[key] = bounded.value;
+      truncated = truncated || bounded.truncated;
+    }
+    if (entries.length > MAX_UNKNOWN_RAW_OBJECT_KEYS) {
+      output.__truncated = {
+        truncated: true,
+        type: "object",
+        remainingKeys: entries.length - MAX_UNKNOWN_RAW_OBJECT_KEYS
+      };
+      truncated = true;
+    }
+    return { value: output, truncated };
+  }
+
+  return { value, truncated: false };
 }

--- a/packages/parser/src/types.ts
+++ b/packages/parser/src/types.ts
@@ -113,6 +113,7 @@ export interface UnknownEventRecord extends ProviderMetadata {
   timestamp?: string;
   topLevelType?: string;
   payloadType?: string;
+  rawTruncated?: boolean;
   raw: JsonObject;
 }
 

--- a/packages/parser/test/cache.test.mjs
+++ b/packages/parser/test/cache.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { copyFile, mkdir, mkdtemp, readFile, rm, unlink, writeFile } from "node:fs/promises";
+import { copyFile, mkdir, mkdtemp, readFile, rm, stat, unlink, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 import test from "node:test";
@@ -178,6 +178,58 @@ test("parseLogCorpusWithCache uses provider-specific default roots", async () =>
     const codexOnly = await parseLogCorpusWithCache({ cacheDir, homeDir: tempHome });
     assert.equal(codexOnly.cache.totalFiles, 1);
     assert.deepEqual(codexOnly.corpus.files.map((file) => file.provider), ["codex"]);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("parseCodexCorpusWithCache writes bounded cache files for large unknown payloads", async () => {
+  const tempDir = await mkdtemp(`${tmpdir()}/codex-log-viewer-cache-large-unknown-`);
+  const sourceDir = join(tempDir, "logs");
+  const cacheDir = join(tempDir, "cache");
+  const sessionPath = join(sourceDir, "large-unknown.jsonl");
+
+  try {
+    await mkdir(sourceDir, { recursive: true });
+    await writeFile(
+      sessionPath,
+      [
+        JSON.stringify({
+          timestamp: "2026-01-01T00:00:00.000Z",
+          type: "session_meta",
+          payload: {
+            id: "large-unknown",
+            timestamp: "2026-01-01T00:00:00.000Z",
+            cwd: "/tmp/cache-app"
+          }
+        }),
+        JSON.stringify({
+          timestamp: "2026-01-01T00:00:01.000Z",
+          type: "event_msg",
+          payload: {
+            type: "future_payload",
+            result: "x".repeat(2_000_000)
+          }
+        })
+      ].join("\n") + "\n",
+      "utf8"
+    );
+
+    const cold = await parseCodexCorpusWithCache({ paths: [sourceDir], cacheDir });
+    assert.equal(cold.cache.cacheStatus, "updated");
+    assert.equal(cold.cache.parsedFiles, 1);
+    assert.equal(cold.corpus.unknownEvents[0]?.rawTruncated, true);
+
+    const manifest = JSON.parse(await readFile(resolve(cacheDir, "manifest.json"), "utf8"));
+    const entry = Object.values(manifest.entries)[0];
+    const cacheFilePath = resolve(cacheDir, "files", entry.cacheFile);
+    const cacheFile = await stat(cacheFilePath);
+    assert.equal(cacheFile.size < 20_000, true);
+
+    const warm = await parseCodexCorpusWithCache({ paths: [sourceDir], cacheDir });
+    assert.equal(warm.cache.cacheStatus, "ready");
+    assert.equal(warm.cache.reusedFiles, 1);
+    assert.equal(warm.corpus.unknownEvents[0]?.raw.payload.result.length, 2_000_000);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/packages/parser/test/parser.test.mjs
+++ b/packages/parser/test/parser.test.mjs
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
 import { copyFile, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
-import test from "node:test";
 import { tmpdir } from "node:os";
-import { dirname, resolve } from "node:path";
+import test from "node:test";
+import { dirname, join, resolve } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { fileURLToPath } from "node:url";
 import { discoverLogFiles, parseCodexLogFile, parseLogCorpus, parseLogFile } from "../dist/index.js";
@@ -198,7 +198,7 @@ test("parseCodexLogFile normalizes response items and tool events", async () => 
   assert.equal(parsed.taskTimings[0]?.durationMs, 12000);
   assert.equal(parsed.taskTimings[0]?.timeToFirstTokenMs, 700);
 
-  assert.equal(parsed.toolEvents.length, 6);
+  assert.equal(parsed.toolEvents.length, 8);
   assert.deepEqual(
     parsed.toolEvents.map((event) => event.eventType),
     [
@@ -207,11 +207,19 @@ test("parseCodexLogFile normalizes response items and tool events", async () => 
       "custom_tool_call",
       "custom_tool_call_output",
       "exec_command_end",
-      "patch_apply_end"
+      "patch_apply_end",
+      "image_generation_call",
+      "image_generation_end"
     ]
   );
   assert.equal(parsed.toolEvents.find((event) => event.eventType === "exec_command_end")?.exitCode, 0);
   assert.equal(parsed.toolEvents.find((event) => event.eventType === "exec_command_end")?.durationMs, 42);
+  const imageGenerationEvents = parsed.toolEvents.filter((event) => event.eventType.startsWith("image_generation_"));
+  assert.deepEqual(
+    imageGenerationEvents.map((event) => event.callId),
+    ["image-call-1", "image-call-1"]
+  );
+  assert.equal(imageGenerationEvents.some((event) => event.content?.includes("redacted-base64-image-data")), false);
   assert.equal(parsed.unknownEvents.length, 2);
   assert.deepEqual(
     parsed.unknownEvents.map((event) => [event.topLevelType, event.payloadType]),
@@ -220,6 +228,41 @@ test("parseCodexLogFile normalizes response items and tool events", async () => 
       ["future_top_level", "future_payload"]
     ]
   );
+});
+
+test("parseCodexLogFile bounds raw previews for oversized unknown events", async () => {
+  const tempDir = await mkdtemp(`${tmpdir()}/codex-log-viewer-large-unknown-`);
+  const fixture = join(tempDir, "large-unknown.jsonl");
+
+  try {
+    await mkdir(tempDir, { recursive: true });
+    await writeFile(
+      fixture,
+      `${JSON.stringify({
+        timestamp: "2026-04-28T10:00:00.000Z",
+        type: "event_msg",
+        payload: {
+          type: "future_payload",
+          value: "x".repeat(10_000)
+        }
+      })}\n`,
+      "utf8"
+    );
+
+    const parsed = await parseCodexLogFile(fixture);
+    const unknown = parsed.unknownEvents[0];
+
+    assert.equal(parsed.unknownEvents.length, 1);
+    assert.equal(unknown?.rawTruncated, true);
+    assert.deepEqual(unknown?.raw.payload.value, {
+      truncated: true,
+      type: "string",
+      length: 10_000
+    });
+    assert.equal(JSON.stringify(parsed).includes("x".repeat(1_000)), false);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
 });
 
 test("parseCodexLogFile extracts visual review comments instead of generated image captions", async () => {

--- a/scripts/check-web-demo-privacy.mjs
+++ b/scripts/check-web-demo-privacy.mjs
@@ -1,0 +1,68 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+const files = [
+  "apps/web-demo/src/data/demo-data.generated.json",
+  "apps/web-demo/src/App.tsx",
+  "apps/web-demo/src/styles.css",
+  "apps/web-demo/src/types.ts",
+  "apps/web-demo/vite.config.ts",
+  "scripts/generate-web-demo-data.mjs",
+  "docs/web-demo.md",
+  "README.md"
+];
+
+const rules = [
+  {
+    name: "OpenAI/GitHub token-like value",
+    pattern: /\b(?:sk-[A-Za-z0-9_-]{20,}|gh[pousr]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,})\b/g
+  },
+  {
+    name: "Slack/AWS token-like value",
+    pattern: /\b(?:xox[baprs]-[A-Za-z0-9-]{20,}|AKIA[0-9A-Z]{16})\b/g
+  },
+  {
+    name: "private key material",
+    pattern: /-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----/g
+  },
+  {
+    name: "unredacted secret assignment",
+    pattern: /\b(?:password|passwd|api[_-]?key|secret|auth[_-]?token|access[_-]?token|refresh[_-]?token|bearer[_-]?token|token)\b\s*[:=]\s*(?!\[redacted\])("[^"]+"|'[^']+'|[^\s`",}]+)/gi
+  },
+  {
+    name: "email address",
+    pattern: /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi
+  },
+  {
+    name: "phone-like number",
+    pattern: /(?:\+?1[-.\s]?)?\(?\d{3}\)?[-.\s]\d{3}[-.\s]\d{4}/g
+  },
+  {
+    name: "non-example macOS home path",
+    pattern: /\/Users\/(?!example\/)[A-Za-z0-9._-]+\//g
+  },
+  {
+    name: "private source project name",
+    pattern: /\b(?:Uira|All Hands|Brown Bag|Bosque|sample-shop|docs-studio)\b/gi
+  }
+];
+
+const findings = [];
+
+for (const file of files) {
+  const body = await readFile(resolve(file), "utf8");
+  for (const rule of rules) {
+    rule.pattern.lastIndex = 0;
+    const count = [...body.matchAll(rule.pattern)].length;
+    if (count > 0) {
+      findings.push(`${file}: ${rule.name} (${count})`);
+    }
+  }
+}
+
+if (findings.length > 0) {
+  process.stderr.write(`Web demo privacy check failed:\n${findings.map((finding) => `- ${finding}`).join("\n")}\n`);
+  process.exit(1);
+}
+
+process.stdout.write(`Web demo privacy check passed for ${files.length} files.\n`);

--- a/scripts/check-web-demo-privacy.mjs
+++ b/scripts/check-web-demo-privacy.mjs
@@ -42,8 +42,8 @@ const rules = [
     pattern: /\/Users\/(?!example\/)[A-Za-z0-9._-]+\//g
   },
   {
-    name: "private source project name",
-    pattern: /\b(?:Uira|All Hands|Brown Bag|Bosque|sample-shop|docs-studio)\b/gi
+    name: "placeholder private source project name",
+    pattern: /\b(?:sample-shop|docs-studio)\b/gi
   }
 ];
 

--- a/scripts/generate-web-demo-data.mjs
+++ b/scripts/generate-web-demo-data.mjs
@@ -1,0 +1,766 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  corpusFromParsedFiles,
+  parseCodexCorpus
+} from "../packages/parser/dist/index.js";
+import {
+  classifyPromptIntent,
+  generateAuditMarkdown,
+  listProjects,
+  projectContextForFile,
+  searchMessages,
+  summarizeParsedCorpus,
+  userMessageCategoryLabel
+} from "../packages/analytics/dist/index.js";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(scriptDir, "..");
+const outputPath = resolve(repoRoot, "apps/web-demo/src/data/demo-data.generated.json");
+const stableGeneratedAt = "2026-06-07T12:00:00.000Z";
+const generatedSourcePath = "generated/synthetic-web-demo";
+const args = new Set(process.argv.slice(2));
+const checkOnly = args.has("--check");
+
+const syntheticProfiles = [
+  {
+    project: "Third-Party Website",
+    slug: "third-party-website",
+    basis: "Synthesized from aggregate patterns in a third-party website project.",
+    cwd: "/Users/example/projects/Third-Party Website",
+    model: "gpt-5.4",
+    sessionCount: 28,
+    promptCount: 250,
+    start: "2026-05-01T14:00:00.000Z",
+    tokenTotals: {
+      inputTokens: 200_914_233,
+      cachedInputTokens: 188_578_944,
+      freshInputTokens: 12_335_289,
+      outputTokens: 1_140_825,
+      reasoningOutputTokens: 427_832,
+      totalTokens: 202_149_737
+    },
+    unknownEvents: 77,
+    parseWarnings: 0,
+    topics: [
+      "homepage handoff",
+      "CMS preview",
+      "lead capture flow",
+      "pricing page",
+      "case study grid",
+      "analytics dashboard",
+      "deployment checklist",
+      "accessibility pass"
+    ],
+    intentCounts: {
+      "git-commands": 52,
+      "deploy-release-run-build": 40,
+      "context-observation": 37,
+      "feature-design": 17,
+      implementation: 15,
+      "bug-fixes": 15,
+      "planning-strategy": 15,
+      "refactor-cleanup": 11,
+      "code-review-qa": 11,
+      research: 10,
+      "data-analysis": 9,
+      "testing-verification": 8,
+      "content-creation": 5,
+      "plan-approvals": 4,
+      documentation: 1
+    }
+  },
+  {
+    project: "Executive Presentation",
+    slug: "executive-presentation",
+    basis: "Synthesized from aggregate patterns in a presentation project.",
+    cwd: "/Users/example/projects/Executive Presentation",
+    model: "gpt-5.5",
+    sessionCount: 30,
+    promptCount: 260,
+    start: "2026-05-06T15:30:00.000Z",
+    tokenTotals: {
+      inputTokens: 1_347_462_305,
+      cachedInputTokens: 1_277_031_040,
+      freshInputTokens: 70_431_265,
+      outputTokens: 5_270_070,
+      reasoningOutputTokens: 1_956_257,
+      totalTokens: 1_354_416_375
+    },
+    unknownEvents: 260,
+    parseWarnings: 0,
+    topics: [
+      "opening narrative",
+      "speaker notes",
+      "customer proof slide",
+      "roadmap section",
+      "team momentum story",
+      "chart annotation",
+      "closing callout",
+      "deck rehearsal"
+    ],
+    intentCounts: {
+      "content-creation": 91,
+      "context-observation": 32,
+      "bug-fixes": 32,
+      "git-commands": 31,
+      "planning-strategy": 20,
+      implementation: 9,
+      "deploy-release-run-build": 7,
+      "testing-verification": 7,
+      "feature-design": 6,
+      documentation: 6,
+      "data-analysis": 3,
+      research: 2,
+      "plan-approvals": 2,
+      "refactor-cleanup": 2,
+      "code-review-qa": 1,
+      other: 9
+    }
+  },
+  {
+    project: "Photographer's Guide",
+    slug: "photographers-guide",
+    basis: "Synthesized from aggregate patterns in a photographer's guide project.",
+    cwd: "/Users/example/projects/Photographer's Guide",
+    model: "gpt-5.5",
+    sessionCount: 27,
+    promptCount: 240,
+    start: "2026-05-11T13:15:00.000Z",
+    tokenTotals: {
+      inputTokens: 558_086_581,
+      cachedInputTokens: 526_279_296,
+      freshInputTokens: 31_807_285,
+      outputTokens: 2_444_642,
+      reasoningOutputTokens: 828_725,
+      totalTokens: 561_169_543
+    },
+    unknownEvents: 340,
+    parseWarnings: 6,
+    topics: [
+      "sunrise route",
+      "birding blind map",
+      "seasonal checklist",
+      "image gallery",
+      "field notes",
+      "print guide",
+      "trip planning",
+      "weather fallback"
+    ],
+    intentCounts: {
+      "context-observation": 35,
+      "git-commands": 34,
+      "bug-fixes": 22,
+      documentation: 19,
+      "deploy-release-run-build": 18,
+      "planning-strategy": 15,
+      "content-creation": 14,
+      "testing-verification": 12,
+      implementation: 11,
+      "data-analysis": 10,
+      "code-review-qa": 9,
+      "refactor-cleanup": 8,
+      "feature-design": 8,
+      research: 7,
+      other: 18
+    }
+  },
+  {
+    project: "Codex Log Viewer",
+    slug: "codex-log-viewer",
+    basis: "Uses real aggregate proportions from the local Codex Log Viewer logs; prompt and response text is synthetic.",
+    cwd: "/Users/example/projects/Codex Log Viewer",
+    model: "gpt-5.5",
+    sessionCount: 26,
+    promptCount: 300,
+    start: "2026-05-16T16:00:00.000Z",
+    tokenTotals: {
+      inputTokens: 1_320_404_566,
+      cachedInputTokens: 1_282_230_272,
+      freshInputTokens: 38_174_294,
+      outputTokens: 3_259_286,
+      reasoningOutputTokens: 1_214_764,
+      totalTokens: 1_324_479_618
+    },
+    unknownEvents: 202,
+    parseWarnings: 0,
+    topics: [
+      "parser cache",
+      "project summary",
+      "search filters",
+      "audit worklog",
+      "native browse flow",
+      "redacted export",
+      "prompt classifier",
+      "web demo"
+    ],
+    intentCounts: {
+      "git-commands": 60,
+      "context-observation": 43,
+      "bug-fixes": 37,
+      "deploy-release-run-build": 31,
+      "feature-design": 31,
+      "planning-strategy": 30,
+      research: 14,
+      "code-review-qa": 11,
+      implementation: 11,
+      "refactor-cleanup": 11,
+      documentation: 8,
+      "data-analysis": 5,
+      "testing-verification": 4,
+      "plan-approvals": 3,
+      "content-creation": 1
+    }
+  }
+];
+
+const tempDir = await mkdtemp(join(tmpdir(), "codex-log-viewer-web-demo-"));
+
+try {
+  await writeSyntheticJsonl(tempDir);
+  const parsedCorpus = await parseCodexCorpus({ paths: [tempDir] });
+  const corpus = sanitizeCorpus(parsedCorpus, tempDir);
+  const projects = listProjects(corpus);
+  const projectNames = ["All Projects", ...projects.map((project) => project.project)];
+  const summaries = Object.fromEntries(
+    projectNames.map((project) => [
+      project,
+      stableSummary(summarizeParsedCorpus(corpus, {
+        paths: [generatedSourcePath],
+        project: project === "All Projects" ? undefined : project
+      }))
+    ])
+  );
+  const allMessages = stableSearch(searchMessages(corpus, {
+    project: "All Projects",
+    role: "all",
+    limit: 5_000
+  }));
+  const submittedMessages = stableSearch(searchMessages(corpus, {
+    project: "All Projects",
+    role: "user",
+    submittedOnly: true,
+    limit: 5_000
+  }));
+
+  const data = {
+    schemaVersion: 2,
+    generatedAt: stableGeneratedAt,
+    source: {
+      kind: "generated-synthetic-codex-jsonl",
+      fixturePath: generatedSourcePath,
+      privacy: "Public demo data is generated from synthetic prompts. Codex Log Viewer metrics use real aggregate proportions, but raw local messages are not included.",
+      profiles: syntheticProfiles.map((profile) => ({
+        project: profile.project,
+        promptCount: profile.promptCount,
+        basis: profile.basis
+      }))
+    },
+    links: {
+      repository: "https://github.com/crispierry/codex-log-viewer",
+      releases: "https://github.com/crispierry/codex-log-viewer/releases",
+      privacyDocs: "https://github.com/crispierry/codex-log-viewer/blob/main/docs/privacy-and-redaction.md"
+    },
+    projects,
+    projectNames,
+    summaries,
+    messages: allMessages.results,
+    submittedMessages: submittedMessages.results,
+    sessionDetails: buildSessionDetails(corpus),
+    auditPreview: buildAuditPreview(corpus)
+  };
+
+  const body = `${JSON.stringify(data, null, 2)}\n`;
+
+  if (checkOnly) {
+    const current = await readFile(outputPath, "utf8");
+    if (current !== body) {
+      process.stderr.write(`${relative(repoRoot, outputPath)} is out of date. Run npm run demo:data.\n`);
+      process.exitCode = 1;
+    } else {
+      process.stdout.write("Web demo data is up to date.\n");
+    }
+  } else {
+    await mkdir(dirname(outputPath), { recursive: true });
+    await writeFile(outputPath, body, "utf8");
+    process.stdout.write(`Wrote ${relative(repoRoot, outputPath)} from generated synthetic profiles.\n`);
+  }
+} finally {
+  await rm(tempDir, { recursive: true, force: true });
+}
+
+async function writeSyntheticJsonl(directory) {
+  for (const profile of syntheticProfiles) {
+    const intentSequence = intentSequenceFor(profile);
+    const promptsBySession = distribute(profile.promptCount, profile.sessionCount);
+    const unknownsBySession = distribute(profile.unknownEvents, profile.sessionCount);
+    const warningsBySession = distribute(profile.parseWarnings, profile.sessionCount);
+    let promptIndex = 0;
+    for (let sessionIndex = 0; sessionIndex < profile.sessionCount; sessionIndex += 1) {
+      const sessionNumber = sessionIndex + 1;
+      const sessionId = `${profile.slug}-${String(sessionNumber).padStart(2, "0")}`;
+      const sessionDate = addMinutes(new Date(profile.start), sessionIndex * 420);
+      const lines = [
+        eventLine(sessionDate, "session_meta", {
+          id: sessionId,
+          timestamp: sessionDate.toISOString(),
+          cwd: profile.cwd,
+          originator: "Codex Desktop",
+          cli_version: "0.128.0-alpha.1",
+          source: "codex-desktop",
+          model_provider: "openai"
+        })
+      ];
+
+      for (let turnOffset = 0; turnOffset < promptsBySession[sessionIndex]; turnOffset += 1) {
+        const turnNumber = turnOffset + 1;
+        const turnId = `${sessionId}-turn-${String(turnNumber).padStart(2, "0")}`;
+        const timestamp = addMinutes(sessionDate, turnOffset * 18 + 1);
+        const intent = intentSequence[promptIndex] ?? "context-observation";
+        const topic = profile.topics[promptIndex % profile.topics.length];
+        const prompt = promptFor(profile, intent, topic, promptIndex);
+        const usage = usageFor(profile, promptIndex);
+        const response = responseFor(profile, intent, topic);
+        const includeTool = shouldIncludeTool(intent, promptIndex);
+
+        lines.push(
+          eventLine(timestamp, "turn_context", {
+            turn_id: turnId,
+            cwd: profile.cwd,
+            current_date: timestamp.toISOString().slice(0, 10),
+            timezone: "America/Los_Angeles",
+            model: promptIndex % 11 === 0 ? `${profile.model}-mini` : profile.model,
+            effort: promptIndex % 5 === 0 ? "high" : promptIndex % 3 === 0 ? "low" : "medium",
+            collaboration_mode: { mode: promptIndex % 13 === 0 ? "plan" : "default" }
+          }),
+          eventLine(addSeconds(timestamp, 1), "event_msg", {
+            type: "task_started",
+            turn_id: turnId,
+            started_at: addSeconds(timestamp, 1).getTime()
+          }),
+          eventLine(addSeconds(timestamp, 2), "event_msg", {
+            type: "user_message",
+            message: `${prompt}\n`,
+            images: [],
+            local_images: [],
+            text_elements: []
+          })
+        );
+
+        if (includeTool) {
+          const callId = `${turnId}-tool`;
+          lines.push(
+            eventLine(addSeconds(timestamp, 4), "response_item", {
+              type: "custom_tool_call",
+              name: toolNameFor(intent),
+              call_id: callId
+            }),
+            eventLine(addSeconds(timestamp, 7), "response_item", {
+              type: "custom_tool_call_output",
+              call_id: callId,
+              output: toolOutputFor(profile, intent, topic)
+            }),
+            eventLine(addSeconds(timestamp, 9), "event_msg", {
+              type: "exec_command_end",
+              cwd: profile.cwd,
+              exit_code: 0,
+              duration: { millis: 120 + (promptIndex % 17) * 43 }
+            })
+          );
+        }
+
+        lines.push(
+          eventLine(addSeconds(timestamp, 12), "event_msg", {
+            type: "agent_message",
+            message: response,
+            phase: "final_answer"
+          }),
+          eventLine(addSeconds(timestamp, 13), "event_msg", {
+            type: "token_count",
+            info: {
+              last_token_usage: usage,
+              total_token_usage: usage,
+              model_context_window: 400_000
+            },
+            rate_limits: {
+              limit_id: "codex",
+              primary: { used_percent: 10 + (promptIndex % 35) }
+            }
+          }),
+          eventLine(addSeconds(timestamp, 14), "event_msg", {
+            type: "task_complete",
+            turn_id: turnId,
+            completed_at: addSeconds(timestamp, 14).getTime(),
+            duration_ms: 24_000 + (promptIndex % 23) * 2_100,
+            time_to_first_token_ms: 650 + (promptIndex % 7) * 120,
+            last_agent_message: response
+          })
+        );
+        promptIndex += 1;
+      }
+
+      for (let index = 0; index < unknownsBySession[sessionIndex]; index += 1) {
+        lines.push(eventLine(addMinutes(sessionDate, 360 + index), "event_msg", {
+          type: "demo_future_event",
+          value: `${profile.slug}-unknown-${index}`
+        }));
+      }
+
+      for (let index = 0; index < warningsBySession[sessionIndex]; index += 1) {
+        lines.push("not json in generated synthetic demo fixture");
+      }
+
+      await writeFile(
+        join(directory, `rollout-${profile.slug}-${String(sessionNumber).padStart(2, "0")}.jsonl`),
+        `${lines.join("\n")}\n`,
+        "utf8"
+      );
+    }
+  }
+}
+
+function sanitizeCorpus(corpus, directory) {
+  const pathMap = new Map(
+    corpus.files.map((file) => [
+      file.filePath,
+      `${generatedSourcePath}/${basename(file.filePath)}`
+    ])
+  );
+  const parsedFiles = corpus.files.map((file) => sanitizeValue(file, pathMap, directory));
+  return corpusFromParsedFiles(parsedFiles);
+}
+
+function sanitizeValue(value, pathMap, directory) {
+  if (typeof value === "string") {
+    if (pathMap.has(value)) {
+      return pathMap.get(value);
+    }
+    return value.replaceAll(directory, generatedSourcePath);
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeValue(item, pathMap, directory));
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [key, sanitizeValue(entry, pathMap, directory)])
+    );
+  }
+  return value;
+}
+
+function stableSummary(summary) {
+  return {
+    ...summary,
+    generatedAt: stableGeneratedAt,
+    filters: {
+      ...summary.filters,
+      paths: [generatedSourcePath]
+    }
+  };
+}
+
+function stableSearch(search) {
+  return {
+    ...search,
+    generatedAt: stableGeneratedAt
+  };
+}
+
+function buildSessionDetails(corpus) {
+  return corpus.files.map((file) => {
+    const context = projectContextForFile(file, corpus);
+    return {
+      id: sessionKey(file),
+      sessionId: file.sessionId,
+      filePath: file.filePath,
+      project: context.project,
+      cwd: context.cwd,
+      firstSeen: firstTimestamp(file),
+      lastSeen: lastTimestamp(file),
+      lineCount: file.lineCount,
+      turns: [],
+      messages: [],
+      tokenUsage: [],
+      taskTimings: [],
+      toolEvents: file.toolEvents,
+      unknownEvents: file.unknownEvents.map((event) => ({
+        filePath: event.filePath,
+        sessionId: event.sessionId,
+        lineNumber: event.lineNumber,
+        timestamp: event.timestamp,
+        topLevelType: event.topLevelType,
+        payloadType: event.payloadType
+      })),
+      warnings: file.warnings,
+      interactions: buildInteractions(file)
+    };
+  }).sort((a, b) => (b.lastSeen ?? "").localeCompare(a.lastSeen ?? ""));
+}
+
+function buildInteractions(file) {
+  return file.messages
+    .filter((message) => message.sourceEvent === "event_msg.user_message")
+    .map((userMessage) => {
+      const turn = file.turns.find((candidate) => candidate.turnId === userMessage.turnId);
+      const responseMessages = file.messages.filter((message) =>
+        message.turnId === userMessage.turnId &&
+        message.lineNumber !== undefined &&
+        userMessage.lineNumber !== undefined &&
+        message.lineNumber > userMessage.lineNumber &&
+        message.role !== "user" &&
+        message.role !== "automation"
+      );
+      const assistantMessages = responseMessages.filter((message) => message.role === "assistant");
+      const assistant = assistantMessages.at(-1) ?? responseMessages.at(-1);
+      const tools = file.toolEvents.filter((event) => event.turnId === userMessage.turnId);
+      const tokenEvent = file.tokenUsage.find((event) => event.turnId === userMessage.turnId);
+      const timing = file.taskTimings.find((event) => event.turnId === userMessage.turnId);
+      const promptIntent = classifyPromptIntent(userMessage.content);
+      return {
+        id: [
+          file.filePath,
+          userMessage.sessionId,
+          userMessage.turnId ?? "",
+          userMessage.lineNumber ?? ""
+        ].join("#"),
+        sessionId: userMessage.sessionId,
+        filePath: userMessage.filePath,
+        turnId: userMessage.turnId,
+        timestamp: userMessage.timestamp,
+        userMessage: userMessage.content.trim(),
+        assistantMessage: assistant?.content.trim() ?? timing?.lastAgentMessage ?? "",
+        model: turn?.model ?? "unknown",
+        effort: turn?.effort,
+        promptIntentKey: promptIntent.key,
+        promptIntent: promptIntent.label,
+        category: userMessageCategoryLabel(userMessage.content),
+        tokenUsage: tokenEvent?.usage,
+        durationMs: timing?.durationMs,
+        timeToFirstTokenMs: timing?.timeToFirstTokenMs,
+        tools,
+        contextMessages: responseMessages
+          .filter((message) => message.role === "developer" || message.role === "system")
+          .map((message) => message.content.trim())
+      };
+    });
+}
+
+function buildAuditPreview(corpus) {
+  const generatedMarkdown = generateAuditMarkdown(corpus, {
+    paths: [generatedSourcePath],
+    project: "Codex Log Viewer",
+    repoPath: "/Users/example/projects/Codex Log Viewer",
+    includeResponses: true,
+    privacy: "public"
+  }).replace(/^Generated: .+$/m, `Generated: ${stableGeneratedAt}`);
+  return {
+    targetPath: "/Users/example/projects/Codex Log Viewer/docs/ai-worklog.md",
+    generatedMarkdown,
+    appendedSections: 26,
+    skippedSections: 0
+  };
+}
+
+function intentSequenceFor(profile) {
+  const sequence = [];
+  for (const [intent, count] of Object.entries(profile.intentCounts)) {
+    for (let index = 0; index < count; index += 1) {
+      sequence.push(intent);
+    }
+  }
+  if (sequence.length !== profile.promptCount) {
+    throw new Error(`${profile.project} intent counts must equal promptCount.`);
+  }
+  return sequence.sort((a, b) => intentSortKey(a).localeCompare(intentSortKey(b)));
+}
+
+function intentSortKey(intent) {
+  const order = [
+    "feature-design",
+    "implementation",
+    "bug-fixes",
+    "git-commands",
+    "deploy-release-run-build",
+    "code-review-qa",
+    "planning-strategy",
+    "research",
+    "documentation",
+    "testing-verification",
+    "refactor-cleanup",
+    "content-creation",
+    "data-analysis",
+    "context-observation",
+    "plan-approvals",
+    "other"
+  ];
+  return `${order.indexOf(intent)}-${intent}`;
+}
+
+function promptFor(profile, intent, topic, index) {
+  const repeated = repeatedPromptFor(intent, profile.project, topic, index);
+  if (repeated) {
+    return repeated;
+  }
+
+  switch (intent) {
+    case "feature-design":
+      return `Design the ${topic} feature for the public experience.`;
+    case "implementation":
+      return `Implement the ${topic} interaction in the app.`;
+    case "bug-fixes":
+      return `Fix the bug where the ${topic} state breaks.`;
+    case "git-commands":
+      return index % 2 === 0 ? "commit and push the latest changes" : `Create a git commit for the ${topic} updates.`;
+    case "deploy-release-run-build":
+      return index % 3 === 0 ? "Run the build and summarize any failures." : `Deploy the ${topic} update after running the production build.`;
+    case "code-review-qa":
+      return `Review the ${topic} changes for QA and accessibility issues.`;
+    case "planning-strategy":
+      return `Plan the next iteration for ${topic}.`;
+    case "research":
+      return `Research the best public examples for ${topic}.`;
+    case "documentation":
+      return `Update the docs for the ${topic} workflow.`;
+    case "testing-verification":
+      return `Write tests for ${topic} and verify the end-to-end flow.`;
+    case "refactor-cleanup":
+      return `Refactor the ${topic} module and clean up duplicate state.`;
+    case "content-creation":
+      return `Draft concise copy for the ${topic} section.`;
+    case "data-analysis":
+      return `Analyze the metrics for ${topic} and summarize the trend.`;
+    case "context-observation":
+      return `Here is the current ${topic} behavior; tell me what stands out.`;
+    case "plan-approvals":
+      return "Looks good, proceed with the plan.";
+    default:
+      return `Think through the ${topic} direction and tell me what feels off.`;
+  }
+}
+
+function repeatedPromptFor(intent, _project, topic, index) {
+  if (index % 31 === 0 && intent === "git-commands") {
+    return "commit and push the latest changes";
+  }
+  if (index % 29 === 0 && intent === "deploy-release-run-build") {
+    return "Run the build and summarize any failures.";
+  }
+  if (index % 37 === 0 && intent === "code-review-qa") {
+    return "Review the latest changes and call out release blockers.";
+  }
+  if (index % 41 === 0 && intent === "context-observation") {
+    return `Here is the current ${topic} behavior; tell me what stands out.`;
+  }
+  return undefined;
+}
+
+function responseFor(profile, intent, topic) {
+  switch (intent) {
+    case "git-commands":
+      return `I prepared the ${profile.project} changes for version control and summarized the branch state.`;
+    case "deploy-release-run-build":
+      return `The ${profile.project} build path is checked, with follow-up notes for ${topic}.`;
+    case "content-creation":
+      return `The ${topic} copy now has a clearer narrative arc and tighter review notes.`;
+    case "bug-fixes":
+      return `I traced the ${topic} issue and adjusted the flow so the failure no longer reproduces.`;
+    case "data-analysis":
+      return `The ${topic} metrics are grouped into a short trend summary with the main driver called out.`;
+    default:
+      return `I updated the ${topic} workstream for ${profile.project} and left the next step visible.`;
+  }
+}
+
+function shouldIncludeTool(intent, index) {
+  return [
+    "implementation",
+    "bug-fixes",
+    "git-commands",
+    "deploy-release-run-build",
+    "testing-verification",
+    "data-analysis",
+    "refactor-cleanup"
+  ].includes(intent) || index % 6 === 0;
+}
+
+function toolNameFor(intent) {
+  if (intent === "git-commands") {
+    return "git";
+  }
+  if (intent === "data-analysis") {
+    return "node";
+  }
+  return "exec_command";
+}
+
+function toolOutputFor(profile, intent, topic) {
+  if (intent === "git-commands") {
+    return "branch clean, staged changes reviewed";
+  }
+  if (intent === "data-analysis") {
+    return `${topic} trend buckets generated for ${profile.project}`;
+  }
+  return `${topic} check completed for ${profile.project}`;
+}
+
+function usageFor(profile, index) {
+  const weight = 0.72 + ((index % 11) * 0.056);
+  const totalWeight = profile.promptCount * 1;
+  return {
+    input_tokens: share(profile.tokenTotals.inputTokens, profile.promptCount, weight, totalWeight),
+    cached_input_tokens: share(profile.tokenTotals.cachedInputTokens, profile.promptCount, weight, totalWeight),
+    output_tokens: share(profile.tokenTotals.outputTokens, profile.promptCount, weight, totalWeight),
+    reasoning_output_tokens: share(profile.tokenTotals.reasoningOutputTokens, profile.promptCount, weight, totalWeight),
+    total_tokens: share(profile.tokenTotals.totalTokens, profile.promptCount, weight, totalWeight)
+  };
+}
+
+function share(total, count, weight, totalWeight) {
+  return Math.max(1, Math.round((total / count) * (weight / (totalWeight / count))));
+}
+
+function distribute(total, buckets) {
+  const base = Math.floor(total / buckets);
+  const remainder = total % buckets;
+  return Array.from({ length: buckets }, (_, index) => base + (index < remainder ? 1 : 0));
+}
+
+function eventLine(timestamp, type, payload) {
+  return JSON.stringify({
+    timestamp: timestamp.toISOString(),
+    type,
+    payload
+  });
+}
+
+function addMinutes(date, minutes) {
+  return new Date(date.getTime() + minutes * 60_000);
+}
+
+function addSeconds(date, seconds) {
+  return new Date(date.getTime() + seconds * 1_000);
+}
+
+function sessionKey(file) {
+  return `${file.filePath}#${file.sessionId}`;
+}
+
+function firstTimestamp(file) {
+  return [
+    ...file.sessions.map((record) => record.timestamp),
+    ...file.turns.map((record) => record.timestamp),
+    ...file.messages.map((record) => record.timestamp)
+  ].filter(Boolean).sort()[0];
+}
+
+function lastTimestamp(file) {
+  return [
+    ...file.sessions.map((record) => record.timestamp),
+    ...file.turns.map((record) => record.timestamp),
+    ...file.messages.map((record) => record.timestamp),
+    ...file.tokenUsage.map((record) => record.timestamp),
+    ...file.taskTimings.map((record) => record.timestamp)
+  ].filter(Boolean).sort().at(-1);
+}


### PR DESCRIPTION
## Summary

- Fix parser cache serialization for very large Codex logs by bounding unknown-event raw previews and treating image-generation events as normalized tool events without retaining generated image data.
- Align the static web demo Overview with the native macOS app UI, including Overview-first navigation, metric tiles, Project Focus, and charts below the fold.
- Rebase onto the latest provider-support work, sync app version metadata to 0.2.9, and keep generated web demo data current.

## Why

The local parser could return HTTP 500 with `Invalid string length` when a very large session included image-generation payloads. The web demo also needed to better match the real native app interface shown in review screenshots.

## Verification

- `wt bootstrap`
- `npm run build -w @codex-log-viewer/parser`
- `node --test packages/parser/test/parser.test.mjs packages/parser/test/cache.test.mjs`
- `npm run check:web-demo-data`
- `npm run version:check`
- `npm run build:web-demo`
- `npm run check:web-demo-privacy`
- `npm test`
- `npm run lint`
- `npm run privacy:scan`
- `git diff --check`