### PR TITLE
[codex] Fix web demo browse layout

### DIFF
--- a/app-version.json
+++ b/app-version.json
@@ -1,5 +1,5 @@
 {
   "major": 0,
-  "minor": 3,
+  "minor": 4,
   "patch": 0
 }

--- a/apps/macos/Sources/CodexLogViewerMac/AppVersion.swift
+++ b/apps/macos/Sources/CodexLogViewerMac/AppVersion.swift
@@ -3,9 +3,9 @@
 
 enum AppVersion {
   static let major = 0
-  static let minor = 3
+  static let minor = 4
   static let patch = 0
-  static let marketingVersion = "0.3.0"
-  static let bundleVersion = "0.3.0"
-  static let displayVersion = "0.3.0"
+  static let marketingVersion = "0.4.0"
+  static let bundleVersion = "0.4.0"
+  static let displayVersion = "0.4.0"
 }

--- a/apps/web-demo/src/App.tsx
+++ b/apps/web-demo/src/App.tsx
@@ -28,6 +28,7 @@ import type {
 
 type Section = "overview" | "browse" | "search" | "audit";
 type SearchRole = MessageRole | "all";
+type DateRange = "all" | "last7" | "last30";
 
 interface BrowseInteraction extends DemoInteraction {
   project: string;
@@ -37,6 +38,13 @@ interface BrowseInteraction extends DemoInteraction {
 
 const demoData = demoDataRaw as DemoData;
 const allProjectsName = "All Projects";
+const browseVisibleMessageCount = 10;
+const latestDemoTimestamp = latestInteractionTimestamp(demoData.sessionDetails);
+const dateRangeOptions: Array<{ id: DateRange; label: string }> = [
+  { id: "all", label: "All Time" },
+  { id: "last7", label: "Last 7 Days" },
+  { id: "last30", label: "Last 30 Days" }
+];
 const sections: Array<{ id: Section; label: string }> = [
   { id: "browse", label: "Browse" },
   { id: "overview", label: "Overview" },
@@ -51,17 +59,24 @@ export default function App() {
   const [query, setQuery] = useState("");
   const [role, setRole] = useState<SearchRole>("all");
   const [selectedSearchId, setSelectedSearchId] = useState<string>();
+  const [selectedDateRange, setSelectedDateRange] = useState<DateRange>("all");
+  const [isDateMenuOpen, setIsDateMenuOpen] = useState(false);
 
   const summary = demoData.summaries[selectedProject] ?? demoData.summaries[allProjectsName];
-  const browseInteractions = useMemo(
+  const dateRangeLabel = dateRangeOptions.find((option) => option.id === selectedDateRange)?.label ?? "All Time";
+  const projectInteractions = useMemo(
     () => interactionsForProject(demoData.sessionDetails, selectedProject),
     [selectedProject]
+  );
+  const browseInteractions = useMemo(
+    () => filterInteractionsByDateRange(projectInteractions, selectedDateRange, latestDemoTimestamp),
+    [projectInteractions, selectedDateRange]
   );
   const selectedInteraction = browseInteractions.find((item) => item.id === selectedInteractionId) ??
     browseInteractions[0];
   const searchResults = useMemo(
-    () => searchMessages(demoData.messages, selectedProject, query, role),
-    [selectedProject, query, role]
+    () => searchMessages(demoData.messages, selectedProject, query, role, selectedDateRange, latestDemoTimestamp),
+    [selectedDateRange, selectedProject, query, role]
   );
   const selectedSearchResult = searchResults.find((item) => item.id === selectedSearchId) ?? searchResults[0];
   const selectedTabId = `section-tab-${selectedSection}`;
@@ -151,10 +166,45 @@ export default function App() {
               <p>{activityRange(summary)} <span aria-hidden="true">·</span> Up to date.</p>
             </div>
 
-            <button className="date-range-button" type="button">
-              <CalendarDays size={15} aria-hidden="true" />
-              <span>All Time</span>
-            </button>
+            <div
+              className="date-range-control"
+              onBlur={(event) => {
+                const nextFocusedElement = event.relatedTarget;
+                if (!(nextFocusedElement instanceof Node) || !event.currentTarget.contains(nextFocusedElement)) {
+                  setIsDateMenuOpen(false);
+                }
+              }}
+            >
+              <button
+                className="date-range-button"
+                type="button"
+                aria-haspopup="menu"
+                aria-expanded={isDateMenuOpen}
+                onClick={() => setIsDateMenuOpen((current) => !current)}
+              >
+                <CalendarDays size={15} aria-hidden="true" />
+                <span>{dateRangeLabel}</span>
+              </button>
+              {isDateMenuOpen && (
+                <div className="date-range-menu" role="menu" aria-label="Date range">
+                  {dateRangeOptions.map((option) => (
+                    <button
+                      key={option.id}
+                      className={option.id === selectedDateRange ? "active" : ""}
+                      type="button"
+                      role="menuitemradio"
+                      aria-checked={option.id === selectedDateRange}
+                      onClick={() => {
+                        setSelectedDateRange(option.id);
+                        setIsDateMenuOpen(false);
+                      }}
+                    >
+                      {option.label}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
 
             <div className="section-tabs" role="tablist" aria-label="Sections">
               {sections.map((section) => {
@@ -385,6 +435,10 @@ function Browse(props: {
   selectedInteraction?: BrowseInteraction;
   onSelect: (id: string) => void;
 }) {
+  const messageWindowSubtitle = props.interactions.length > browseVisibleMessageCount
+    ? `${formatNumber(props.interactions.length)} sent · ${browseVisibleMessageCount} at a time`
+    : `${formatNumber(props.interactions.length)} sent`;
+
   return (
     <section className="browser-grid">
       <div className="list-panel">
@@ -402,15 +456,18 @@ function Browse(props: {
             >
               <span className="prompt-row-meta">
                 <PromptIntentBadge label={interaction.promptIntent} intentKey={interaction.promptIntentKey} />
-                <span>{interaction.project}</span>
-                <span>{formatDateTime(interaction.timestamp)}</span>
+                <span className="prompt-project" title={interaction.project}>
+                  <Folder size={12} aria-hidden="true" />
+                  <span>{interaction.project}</span>
+                </span>
+                <span title={formatDateTime(interaction.timestamp)}>{formatDateTime(interaction.timestamp)}</span>
                 <span>{interaction.model}</span>
               </span>
               <strong>{interaction.userMessage}</strong>
             </button>
           ))}
         </div>
-        <BrowserStatusBar title="User Messages" subtitle={`${formatNumber(props.interactions.length)} sent`} />
+        <BrowserStatusBar title="User Messages" subtitle={messageWindowSubtitle} />
       </div>
 
       <div className="detail-panel">
@@ -798,11 +855,17 @@ function searchMessages(
   messages: MessageSearchResult[],
   project: string,
   query: string,
-  role: SearchRole
+  role: SearchRole,
+  dateRange: DateRange,
+  latestTimestamp?: string
 ) {
   const normalizedQuery = query.trim().toLowerCase();
+  const cutoff = dateRangeCutoff(dateRange, latestTimestamp);
   return messages.filter((message) => {
     if (project !== allProjectsName && message.project !== project) {
+      return false;
+    }
+    if (cutoff && !isTimestampInRange(message.timestamp, cutoff)) {
       return false;
     }
     if (role !== "all" && message.role !== role) {
@@ -813,6 +876,47 @@ function searchMessages(
     }
     return `${message.content} ${message.snippet} ${message.project}`.toLowerCase().includes(normalizedQuery);
   });
+}
+
+function filterInteractionsByDateRange(
+  interactions: BrowseInteraction[],
+  dateRange: DateRange,
+  latestTimestamp?: string
+) {
+  const cutoff = dateRangeCutoff(dateRange, latestTimestamp);
+  if (!cutoff) {
+    return interactions;
+  }
+  return interactions.filter((interaction) => isTimestampInRange(interaction.timestamp, cutoff));
+}
+
+function latestInteractionTimestamp(sessionDetails: SessionDetail[]) {
+  return sessionDetails
+    .flatMap((session) => session.interactions.map((interaction) => interaction.timestamp).filter(Boolean))
+    .sort()
+    .at(-1);
+}
+
+function dateRangeCutoff(dateRange: DateRange, latestTimestamp?: string) {
+  if (dateRange === "all" || !latestTimestamp) {
+    return undefined;
+  }
+  const latestDate = new Date(latestTimestamp);
+  if (Number.isNaN(latestDate.getTime())) {
+    return undefined;
+  }
+  const days = dateRange === "last7" ? 7 : 30;
+  const cutoff = new Date(latestDate);
+  cutoff.setDate(cutoff.getDate() - days);
+  return cutoff;
+}
+
+function isTimestampInRange(timestamp: string | undefined, cutoff: Date) {
+  if (!timestamp) {
+    return false;
+  }
+  const date = new Date(timestamp);
+  return !Number.isNaN(date.getTime()) && date >= cutoff;
 }
 
 function interactionSubtitle(interaction: BrowseInteraction) {

--- a/apps/web-demo/src/App.tsx
+++ b/apps/web-demo/src/App.tsx
@@ -1,5 +1,5 @@
 import type { CSSProperties, ReactNode } from "react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   CalendarDays,
   CheckCircle2,
@@ -435,9 +435,33 @@ function Browse(props: {
   selectedInteraction?: BrowseInteraction;
   onSelect: (id: string) => void;
 }) {
+  const promptListRef = useRef<HTMLDivElement>(null);
+  const [browseRowHeight, setBrowseRowHeight] = useState(52);
   const messageWindowSubtitle = props.interactions.length > browseVisibleMessageCount
     ? `${formatNumber(props.interactions.length)} sent · ${browseVisibleMessageCount} at a time`
     : `${formatNumber(props.interactions.length)} sent`;
+
+  useEffect(() => {
+    const promptList = promptListRef.current;
+    if (!promptList) {
+      return;
+    }
+
+    const updateRowHeight = () => {
+      const availableHeight = promptList.clientHeight;
+      const rowGapTotal = 4 * (browseVisibleMessageCount - 1);
+      const nextHeight = Math.max(
+        52,
+        Math.floor((availableHeight - rowGapTotal) / browseVisibleMessageCount)
+      );
+      setBrowseRowHeight(nextHeight);
+    };
+
+    updateRowHeight();
+    const resizeObserver = new ResizeObserver(updateRowHeight);
+    resizeObserver.observe(promptList);
+    return () => resizeObserver.disconnect();
+  }, []);
 
   return (
     <section className="browser-grid">
@@ -446,7 +470,11 @@ function Browse(props: {
           <Send size={19} aria-hidden="true" />
           <h2>User Messages</h2>
         </div>
-        <div className="prompt-list">
+        <div
+          className="prompt-list"
+          ref={promptListRef}
+          style={{ "--browse-row-height": `${browseRowHeight}px` } as CSSProperties}
+        >
           {props.interactions.map((interaction) => (
             <button
               key={interaction.id}

--- a/apps/web-demo/src/styles.css
+++ b/apps/web-demo/src/styles.css
@@ -747,11 +747,7 @@ button {
 }
 
 .list-panel {
-  grid-template-rows: auto auto auto;
-  align-self: start;
-  overflow: hidden;
   border-right: 1px solid var(--sidebar-border);
-  border-bottom: 1px solid var(--sidebar-border);
 }
 
 .column-title {
@@ -773,7 +769,6 @@ button {
   align-content: start;
   gap: var(--browse-row-gap);
   min-height: 0;
-  max-height: calc((var(--browse-row-height) * 10) + (var(--browse-row-gap) * 9) + 8px);
   overflow-y: auto;
   padding: 0 8px 8px;
 }
@@ -1378,6 +1373,11 @@ button {
 
   .prompt-list {
     max-height: 380px;
+  }
+
+  .prompt-row {
+    height: var(--browse-row-height);
+    min-height: var(--browse-row-height);
   }
 
   .detail-columns,

--- a/apps/web-demo/src/styles.css
+++ b/apps/web-demo/src/styles.css
@@ -69,7 +69,7 @@ button {
 
 .app-shell {
   display: grid;
-  grid-template-columns: minmax(0, 1fr);
+  grid-template-columns: 238px minmax(0, 1fr);
   min-height: 100vh;
   background: var(--content-bg);
 }
@@ -77,7 +77,7 @@ button {
 .sidebar {
   position: sticky;
   top: 0;
-  display: none;
+  display: flex;
   flex-direction: column;
   gap: 14px;
   height: 100vh;
@@ -292,6 +292,42 @@ button {
   color: var(--text);
   font-size: 0.84rem;
   font-weight: 500;
+}
+
+.date-range-control {
+  position: relative;
+  justify-self: end;
+}
+
+.date-range-menu {
+  position: absolute;
+  z-index: 10;
+  top: calc(100% + 6px);
+  right: 0;
+  display: grid;
+  min-width: 150px;
+  padding: 5px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  background: var(--group-bg-raised);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.32);
+}
+
+.date-range-menu button {
+  min-height: 28px;
+  padding: 5px 9px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text);
+  font-size: 0.82rem;
+  font-weight: 600;
+  text-align: left;
+}
+
+.date-range-menu button:hover,
+.date-range-menu button.active {
+  background: rgba(255, 255, 255, 0.12);
 }
 
 .native-button.prominent {
@@ -687,9 +723,13 @@ button {
 }
 
 .browser-grid {
+  --browse-row-gap: 4px;
+  --browse-row-height: 52px;
   display: grid;
   grid-template-columns: minmax(260px, 380px) minmax(360px, 1fr);
-  min-height: calc(100vh - 73px);
+  height: calc(100vh - 73px);
+  min-height: 0;
+  overflow: hidden;
 }
 
 .list-panel,
@@ -697,6 +737,7 @@ button {
   display: grid;
   grid-template-rows: auto minmax(0, 1fr) auto;
   min-width: 0;
+  min-height: 0;
   background: var(--content-bg);
 }
 
@@ -721,7 +762,9 @@ button {
 .prompt-list {
   display: grid;
   align-content: start;
-  gap: 4px;
+  gap: var(--browse-row-gap);
+  min-height: 0;
+  max-height: calc((var(--browse-row-height) * 10) + (var(--browse-row-gap) * 9) + 8px);
   overflow-y: auto;
   padding: 0 8px 8px;
 }
@@ -730,7 +773,10 @@ button {
   display: grid;
   gap: 6px;
   width: 100%;
-  padding: 10px;
+  height: var(--browse-row-height);
+  min-height: var(--browse-row-height);
+  overflow: hidden;
+  padding: 7px 9px;
   border: 1px solid rgba(255, 255, 255, 0.05);
   border-radius: 8px;
   background:
@@ -748,29 +794,49 @@ button {
 }
 
 .prompt-row-meta {
-  display: flex;
-  align-items: baseline;
-  gap: 8px;
+  display: grid;
+  grid-template-columns: minmax(62px, 98px) minmax(92px, 1fr) minmax(86px, 118px) 46px;
+  align-items: center;
+  column-gap: 6px;
   min-width: 0;
+  overflow: hidden;
   color: var(--secondary);
-  font-size: 0.73rem;
+  font-size: 0.68rem;
+  white-space: nowrap;
 }
 
 .prompt-row-meta > span:not(.prompt-intent-badge) {
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.prompt-project {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.prompt-project svg {
+  flex: 0 0 auto;
+}
+
+.prompt-project span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .prompt-row strong {
   display: -webkit-box;
   overflow: hidden;
   color: var(--text);
-  font-size: 0.9rem;
+  font-size: 0.82rem;
   font-weight: 500;
-  line-height: 1.32;
+  line-height: 1.2;
   -webkit-box-orient: vertical;
-  -webkit-line-clamp: 4;
+  -webkit-line-clamp: 1;
 }
 
 .prompt-intent-badge {
@@ -783,6 +849,7 @@ button {
 }
 
 .interaction-scroll {
+  min-height: 0;
   overflow-y: auto;
 }
 
@@ -1259,7 +1326,7 @@ button {
     grid-template-columns: minmax(0, 1fr);
   }
 
-  .date-range-button,
+  .date-range-control,
   .section-tabs {
     justify-self: start;
   }
@@ -1363,6 +1430,10 @@ button {
 
   .native-button,
   .date-range-button {
+    width: 100%;
+  }
+
+  .date-range-control {
     width: 100%;
   }
 

--- a/apps/web-demo/src/styles.css
+++ b/apps/web-demo/src/styles.css
@@ -238,7 +238,11 @@ button {
 }
 
 .workspace {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
   min-width: 0;
+  height: 100vh;
+  overflow: hidden;
   background: var(--content-bg);
 }
 
@@ -371,7 +375,8 @@ button {
 }
 
 #section-panel {
-  min-height: calc(100vh - 73px);
+  min-height: 0;
+  overflow: auto;
 }
 
 .section-stack {
@@ -727,7 +732,7 @@ button {
   --browse-row-height: 52px;
   display: grid;
   grid-template-columns: minmax(260px, 380px) minmax(360px, 1fr);
-  height: calc(100vh - 73px);
+  height: 100%;
   min-height: 0;
   overflow: hidden;
 }
@@ -742,7 +747,11 @@ button {
 }
 
 .list-panel {
+  grid-template-rows: auto auto auto;
+  align-self: start;
+  overflow: hidden;
   border-right: 1px solid var(--sidebar-border);
+  border-bottom: 1px solid var(--sidebar-border);
 }
 
 .column-title {
@@ -1358,6 +1367,7 @@ button {
 
   .browser-grid {
     grid-template-columns: 1fr;
+    height: auto;
     min-height: 0;
   }
 

--- a/docs/ai-worklog.md
+++ b/docs/ai-worklog.md
@@ -17,9 +17,11 @@ Related commit/PR: TBD
 
 > Clicking here is not doing anything
 
+> The messages should symbolize the end of the app. Right now there is a dead space at the end so either let the messages go all the way to the bottom or move the bottom up
+
 ### Interpreted Intent
 
-The user wanted the static web demo Browse view to stop expanding the page with every message and instead show a finite ten-message window with an internal scrollbar, while preserving a visible Projects sidebar/column like the native app and making the date range control interactive.
+The user wanted the static web demo Browse view to stop expanding the page with every message and instead show a finite ten-message window with an internal scrollbar, while preserving a visible Projects sidebar/column like the native app, making the date range control interactive, and removing the dead space below the capped message list.
 
 ### Response / Work Done
 
@@ -31,6 +33,7 @@ The user wanted the static web demo Browse view to stop expanding the page with 
 - Added a folder icon and truncation behavior to keep the project column visible in compact rows.
 - Restored the Projects sidebar as a desktop column in the web demo shell.
 - Made the date range control open a menu and filter Browse/Search data for all time, last 7 days, or last 30 days.
+- Moved the Browse message panel bottom/status edge up so it ends directly below the capped message list instead of leaving a large blank area.
 
 ### Privacy Notes
 
@@ -43,7 +46,7 @@ No raw Codex logs, private prompts, private paths, screenshots, recordings, expo
 - Ran `npm run check:web-demo-privacy`.
 - Ran `npm run build:web-demo`.
 - Ran `git diff --check`.
-- Verified the local web demo preview in the in-app browser: the Projects sidebar displayed as a desktop column, Browse showed 10 fully visible message rows, the page itself did not overflow, the message list had scrollable overflow, the date menu opened and filtered Browse data, and there were no browser console errors.
+- Verified the local web demo preview in the in-app browser: the Projects sidebar displayed as a desktop column, Browse showed 10 fully visible message rows, the page itself did not overflow, the message list had scrollable overflow, the message panel bottom sat directly under the capped list, the date menu opened and filtered Browse data, and there were no browser console errors.
 
 ## 2026-06-07 - Fix PR Version Check Failure
 

--- a/docs/ai-worklog.md
+++ b/docs/ai-worklog.md
@@ -2,6 +2,40 @@
 
 Sanitized audit trail of AI-assisted work on this project.
 
+## 2026-06-07 - Fix PR 22 Version Check Failure
+
+Status: Completed
+Related commit/PR: PR #22
+
+### User Messages
+
+> the PR is failing again
+
+> Implement your fix
+
+### Interpreted Intent
+
+The user wanted the failing GitHub Actions check on PR #22 diagnosed and corrected so the web demo Browse layout PR can pass the repository verification policy.
+
+### Response / Work Done
+
+- Inspected PR #22 checks and confirmed the `verify` job failed on the required app-version check.
+- Updated the branch from `origin/main`.
+- Ran the PR version bump workflow to update app metadata from `0.3.0` to `0.4.0`.
+
+### Privacy Notes
+
+No raw Codex logs, private prompts, session contents, screenshots, recordings, export payloads, credentials, secrets, or local session paths were added.
+
+### Verification
+
+- Ran `wt bootstrap`.
+- Ran `node scripts/check-app-version.mjs --compare-ref origin/main --require-pr-minor`.
+- Ran `npm run typecheck -w @codex-log-viewer/web-demo`.
+- Ran `npm run check:web-demo-privacy`.
+- Ran `npm run build:web-demo`.
+- Ran `git diff --check`.
+
 ## 2026-06-07 - Limit Web Demo Browse Message Window
 
 Status: Completed

--- a/docs/ai-worklog.md
+++ b/docs/ai-worklog.md
@@ -19,9 +19,11 @@ Related commit/PR: TBD
 
 > The messages should symbolize the end of the app. Right now there is a dead space at the end so either let the messages go all the way to the bottom or move the bottom up
 
+> The messages should symbolize the end of the app. Right now there is a dead space at the end so either let the messages go all the way to the bottom or move the bottom up
+
 ### Interpreted Intent
 
-The user wanted the static web demo Browse view to stop expanding the page with every message and instead show a finite ten-message window with an internal scrollbar, while preserving a visible Projects sidebar/column like the native app, making the date range control interactive, and removing the dead space below the capped message list.
+The user wanted the static web demo Browse view to stop expanding the page with every message and instead show a finite ten-message window with an internal scrollbar, while preserving a visible Projects sidebar/column like the native app, making the date range control interactive, and removing the dead space by letting the message rows define the Browse panel height.
 
 ### Response / Work Done
 
@@ -33,7 +35,7 @@ The user wanted the static web demo Browse view to stop expanding the page with 
 - Added a folder icon and truncation behavior to keep the project column visible in compact rows.
 - Restored the Projects sidebar as a desktop column in the web demo shell.
 - Made the date range control open a menu and filter Browse/Search data for all time, last 7 days, or last 30 days.
-- Moved the Browse message panel bottom/status edge up so it ends directly below the capped message list instead of leaving a large blank area.
+- Sized the Browse message rows dynamically so the ten-row message viewport fills the available message column height instead of leaving a large blank area.
 
 ### Privacy Notes
 
@@ -46,7 +48,7 @@ No raw Codex logs, private prompts, private paths, screenshots, recordings, expo
 - Ran `npm run check:web-demo-privacy`.
 - Ran `npm run build:web-demo`.
 - Ran `git diff --check`.
-- Verified the local web demo preview in the in-app browser: the Projects sidebar displayed as a desktop column, Browse showed 10 fully visible message rows, the page itself did not overflow, the message list had scrollable overflow, the message panel bottom sat directly under the capped list, the date menu opened and filtered Browse data, and there were no browser console errors.
+- Verified the local web demo preview in the in-app browser: the Projects sidebar displayed as a desktop column, Browse showed 10 fully visible message rows, the page itself did not overflow, the message list had scrollable overflow, the message rows filled the message column height, the date menu opened and filtered Browse data, and there were no browser console errors.
 
 ## 2026-06-07 - Fix PR Version Check Failure
 

--- a/docs/ai-worklog.md
+++ b/docs/ai-worklog.md
@@ -2,6 +2,49 @@
 
 Sanitized audit trail of AI-assisted work on this project.
 
+## 2026-06-07 - Limit Web Demo Browse Message Window
+
+Status: Completed
+Related commit/PR: TBD
+
+### User Messages
+
+> The web demo for the app has one major mistake. We should only show ten messages. Right now it's infinite and it's showing all the messages. We don't want to do that so when I click on Browse, you have an infinite page size. The page size should be finite and there should be a scroll bar to scroll through the messages
+
+> You're also missing the project column
+
+> Where is the Projects column?
+
+> Clicking here is not doing anything
+
+### Interpreted Intent
+
+The user wanted the static web demo Browse view to stop expanding the page with every message and instead show a finite ten-message window with an internal scrollbar, while preserving a visible Projects sidebar/column like the native app and making the date range control interactive.
+
+### Response / Work Done
+
+- Capped the Browse message list presentation to a fixed ten-row viewport.
+- Kept all synthetic Browse messages available in the internal scrollable list.
+- Made the Browse page itself viewport-bounded so the document no longer grows with the message count.
+- Added a compact Browse row treatment and status text that reflects the ten-at-a-time message window.
+- Changed Browse rows to use distinct metadata columns for category, project, date/time, and model.
+- Added a folder icon and truncation behavior to keep the project column visible in compact rows.
+- Restored the Projects sidebar as a desktop column in the web demo shell.
+- Made the date range control open a menu and filter Browse/Search data for all time, last 7 days, or last 30 days.
+
+### Privacy Notes
+
+No raw Codex logs, private prompts, private paths, screenshots, recordings, export payloads, credentials, secrets, or local session content were added. The web demo remains synthetic.
+
+### Verification
+
+- Ran `wt bootstrap`.
+- Ran `npm run typecheck -w @codex-log-viewer/web-demo`.
+- Ran `npm run check:web-demo-privacy`.
+- Ran `npm run build:web-demo`.
+- Ran `git diff --check`.
+- Verified the local web demo preview in the in-app browser: the Projects sidebar displayed as a desktop column, Browse showed 10 fully visible message rows, the page itself did not overflow, the message list had scrollable overflow, the date menu opened and filtered Browse data, and there were no browser console errors.
+
 ## 2026-06-07 - Fix PR Version Check Failure
 
 Status: Completed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-log-viewer",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-log-viewer",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "workspaces": [
         "packages/*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-log-viewer",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "description": "Local-first native macOS app and parser for OpenAI Codex session logs.",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- Restores the Projects sidebar column in the static web demo desktop layout.
- Bounds Browse to a ten-message viewport with internal scrolling instead of letting the page grow indefinitely.
- Adds structured Browse row metadata columns for category, project, date/time, and model.
- Makes the date range control interactive with All Time, Last 7 Days, and Last 30 Days filtering for Browse/Search data.
- Updates the AI worklog for the assisted UI fix.

## Why

The web demo had drifted from the native app: Browse could expand as an effectively infinite page, the desktop Projects column was hidden, and the date range control looked clickable but did nothing.

## Verification

- `wt bootstrap`
- `npm run typecheck -w @codex-log-viewer/web-demo`
- `npm run check:web-demo-privacy`
- `npm run build:web-demo`
- `git diff --check`
- Verified in the local browser preview that the Projects sidebar is visible, Browse shows 10 rows at a time with internal scrolling, date filtering works, and there are no console errors.