### PR TITLE
Clarify audit preview save flow

### DIFF
--- a/app-version.json
+++ b/app-version.json
@@ -1,5 +1,5 @@
 {
   "major": 0,
-  "minor": 4,
+  "minor": 5,
   "patch": 0
 }

--- a/apps/macos/Sources/CodexLogViewerMac/AppModel.swift
+++ b/apps/macos/Sources/CodexLogViewerMac/AppModel.swift
@@ -99,6 +99,7 @@ final class AppModel: ObservableObject {
   @Published var auditReviewMarkdown = ""
   @Published var auditStatusMessage: String?
   @Published var isAuditLoading = false
+  @Published private var auditSavedTargetPath: String?
   @Published var evalsSummary: PromptIntentEvalMessageSummary?
   @Published var selectedEvalMessageID: PromptIntentEvalMessage.ID?
   @Published var evalCategoryKeyFilter: String?
@@ -400,6 +401,11 @@ final class AppModel: ObservableObject {
 
   var canApproveAudit: Bool {
     auditPreview != nil && !auditReviewMarkdown.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !isAuditLoading
+  }
+
+  var canOpenAuditWorklog: Bool {
+    guard let auditPreview else { return false }
+    return auditPreview.existingMarkdown != nil || auditSavedTargetPath == auditPreview.targetPath
   }
 
   var dateRangeButtonTitle: String {
@@ -1550,6 +1556,7 @@ final class AppModel: ObservableObject {
         guard !Task.isCancelled, requestID == auditRequestID else { return }
         auditPreview = preview
         auditReviewMarkdown = preview.mergedMarkdown
+        auditSavedTargetPath = nil
         auditStatusMessage = auditStatusText(for: preview)
         isAuditLoading = false
       } catch is CancellationError {
@@ -1582,6 +1589,7 @@ final class AppModel: ObservableObject {
         auditStatusMessage = "Saving audit worklog."
         let result = try await api.writeAudit(repoPath: repoPath, targetPath: auditPreview.targetPath, markdown: markdown)
         guard !Task.isCancelled, requestID == auditRequestID else { return }
+        auditSavedTargetPath = result.targetPath
         auditStatusMessage = "Saved \(result.bytesWritten.formatted()) bytes to \(URL(fileURLWithPath: result.targetPath).lastPathComponent)."
         isAuditLoading = false
       } catch is CancellationError {
@@ -1595,7 +1603,7 @@ final class AppModel: ObservableObject {
   }
 
   func openAuditWorklog() {
-    guard let auditPreview else { return }
+    guard let auditPreview, canOpenAuditWorklog else { return }
     NSWorkspace.shared.open(URL(fileURLWithPath: auditPreview.targetPath))
   }
 
@@ -1611,6 +1619,7 @@ final class AppModel: ObservableObject {
     auditPreview = nil
     auditReviewMarkdown = ""
     auditStatusMessage = nil
+    auditSavedTargetPath = nil
     isAuditLoading = false
   }
 
@@ -1635,7 +1644,7 @@ final class AppModel: ObservableObject {
       return "No new generated sections. Existing worklog is up to date for this selection."
     }
     let sectionText = preview.appendedSections == 1 ? "section" : "sections"
-    return "Ready to review \(preview.appendedSections.formatted()) new \(sectionText)."
+    return "Ready to review \(preview.appendedSections.formatted()) new \(sectionText). Save Worklog writes the file."
   }
 
   private func targetWorklogPath(for repoPath: String) -> String {
@@ -2759,12 +2768,54 @@ final class AppModel: ObservableObject {
     exportDirectoryPath = previousExportDirectoryPath
 
     let previousAuditRepoPath = auditRepoPathDraft
-    setAuditRepoPathDraft(FileManager.default.temporaryDirectory.appendingPathComponent("codex-log-viewer-audit-smoke").path)
+    let auditSmokeURL = FileManager.default.temporaryDirectory.appendingPathComponent("codex-log-viewer-audit-smoke-\(UUID().uuidString)")
+    defer {
+      auditRepoPathDraft = previousAuditRepoPath
+      clearAuditPreview()
+      try? FileManager.default.removeItem(at: auditSmokeURL)
+    }
+    setAuditRepoPathDraft(auditSmokeURL.path)
     guard canGenerateAudit else {
       throw AppSmokeError.unexpected("Manual Audit repository path entry did not enable preview generation.")
     }
-    auditRepoPathDraft = previousAuditRepoPath
-    clearAuditPreview()
+    let auditSmokePreview = try await api.auditPreview(
+      repoPath: auditSmokeURL.path,
+      project: AppConstants.allProjectsName,
+      filters: dateFilters,
+      includeResponses: true
+    )
+    auditPreview = auditSmokePreview
+    auditReviewMarkdown = auditSmokePreview.mergedMarkdown
+    auditSavedTargetPath = nil
+    let expectedAuditTarget = auditSmokeURL
+      .appendingPathComponent("docs")
+      .appendingPathComponent("ai-worklog.md")
+      .path
+    guard auditSmokePreview.targetPath == expectedAuditTarget else {
+      throw AppSmokeError.unexpected("The Audit preview target path did not match the selected repository.")
+    }
+    guard !FileManager.default.fileExists(atPath: auditSmokePreview.targetPath) else {
+      throw AppSmokeError.unexpected("The Audit preview unexpectedly created the worklog before approval.")
+    }
+    guard !canOpenAuditWorklog else {
+      throw AppSmokeError.unexpected("The Audit Open Worklog action enabled before a worklog file existed.")
+    }
+    let auditSmokeWrite = try await api.writeAudit(
+      repoPath: auditSmokeURL.path,
+      targetPath: auditSmokePreview.targetPath,
+      markdown: auditSmokePreview.mergedMarkdown
+    )
+    auditSavedTargetPath = auditSmokeWrite.targetPath
+    guard FileManager.default.fileExists(atPath: auditSmokePreview.targetPath) else {
+      throw AppSmokeError.unexpected("The Audit approval did not create the worklog file.")
+    }
+    let savedAuditMarkdown = try String(contentsOfFile: auditSmokePreview.targetPath, encoding: .utf8)
+    guard auditSmokeWrite.bytesWritten > 0,
+      savedAuditMarkdown.contains("# AI Worklog"),
+      canOpenAuditWorklog
+    else {
+      throw AppSmokeError.unexpected("The Audit approval did not save a readable worklog.")
+    }
   }
 
   private func currentFilters(refreshToken: Int = 0, rebuildCache: Bool = false) -> LogFilters {

--- a/apps/macos/Sources/CodexLogViewerMac/AppVersion.swift
+++ b/apps/macos/Sources/CodexLogViewerMac/AppVersion.swift
@@ -3,9 +3,9 @@
 
 enum AppVersion {
   static let major = 0
-  static let minor = 4
+  static let minor = 5
   static let patch = 0
-  static let marketingVersion = "0.4.0"
-  static let bundleVersion = "0.4.0"
-  static let displayVersion = "0.4.0"
+  static let marketingVersion = "0.5.0"
+  static let bundleVersion = "0.5.0"
+  static let displayVersion = "0.5.0"
 }

--- a/apps/macos/Sources/CodexLogViewerMac/RootView.swift
+++ b/apps/macos/Sources/CodexLogViewerMac/RootView.swift
@@ -1167,7 +1167,7 @@ struct AuditControlBar: View {
         Button {
           model.generateAuditPreview()
         } label: {
-          Label("Generate", systemImage: "wand.and.stars")
+          Label("Generate Preview", systemImage: "wand.and.stars")
         }
         .disabled(!model.canGenerateAudit)
         .accessibilityIdentifier("audit-generate-button")
@@ -1175,7 +1175,7 @@ struct AuditControlBar: View {
         Button {
           model.approveAuditMarkdown()
         } label: {
-          Label("Approve", systemImage: "checkmark.seal")
+          Label("Save Worklog", systemImage: "square.and.arrow.down")
         }
         .buttonStyle(.borderedProminent)
         .disabled(!model.canApproveAudit)
@@ -1217,7 +1217,8 @@ struct AuditPreviewHeader: View {
       } label: {
         Label("Open Worklog", systemImage: "arrow.up.forward.app")
       }
-      .disabled(model.auditPreview == nil)
+      .disabled(!model.canOpenAuditWorklog)
+      .help(model.canOpenAuditWorklog ? "Open saved worklog" : "Save the worklog before opening it")
       .accessibilityIdentifier("audit-open-worklog-button")
     }
     .padding(.horizontal, 18)

--- a/docs/ai-worklog.md
+++ b/docs/ai-worklog.md
@@ -2,6 +2,45 @@
 
 Sanitized audit trail of AI-assisted work on this project.
 
+## 2026-06-24 - Clarify Native Audit Preview And Save Flow
+
+Status: Completed
+Related commit/PR: TBD
+
+### User Messages
+
+> I went to our app, selected the content campaign animation project
+>
+> then I tried to generate the audit file - but nothing was created
+>
+> has this regressed?
+
+### Interpreted Intent
+
+The user wanted to know whether the native Audit workflow had regressed after selecting a project and attempting to generate an audit worklog, because no file appeared.
+
+### Response / Work Done
+
+- Traced the native Audit flow through the Swift app and local server.
+- Confirmed the server write endpoint still creates `docs/ai-worklog.md` when the reviewed Markdown is saved.
+- Clarified the native Audit controls so the first action is labeled `Generate Preview` and the file-writing action is labeled `Save Worklog`.
+- Prevented `Open Worklog` from enabling after a preview when no saved file exists yet.
+- Added native smoke coverage that proves preview does not create the worklog, then save creates a readable worklog file.
+- Rebuilt, packaged, smoke-tested, and relaunched the native macOS app for review.
+
+### Privacy Notes
+
+No raw Codex logs, private prompts, session contents, screenshots, recordings, export payloads, credentials, secrets, or local session paths were added. Verification used sanitized fixtures and temporary smoke-test directories.
+
+### Verification
+
+- Ran `wt bootstrap`.
+- Ran `npm run build:mac`.
+- Ran `npm run package:mac`.
+- Ran `npm run smoke:mac-ui`; the first attempt left the packaged app and bundled engine running, then passed on a clean rerun after cleanup.
+- Ran `npm run smoke:mac-package`.
+- Ran `npm run check:mac-accessibility`.
+
 ## 2026-06-07 - Fix PR 22 Version Check Failure
 
 Status: Completed

--- a/docs/ai-worklog.md
+++ b/docs/ai-worklog.md
@@ -2,6 +2,37 @@
 
 Sanitized audit trail of AI-assisted work on this project.
 
+## 2026-06-24 - Fix PR 26 Version Check Failure
+
+Status: Completed
+Related commit/PR: PR #26
+
+### User Messages
+
+> github is failing
+
+> do it
+
+### Interpreted Intent
+
+The user wanted the failing GitHub Actions check on PR #26 diagnosed and fixed.
+
+### Response / Work Done
+
+- Inspected PR #26 checks and confirmed the `verify` job failed on the required app-version check.
+- Ran the PR version bump workflow to update app metadata from `0.4.0` to `0.5.0`.
+
+### Privacy Notes
+
+No raw Codex logs, private prompts, session contents, screenshots, recordings, export payloads, credentials, secrets, or local session paths were added.
+
+### Verification
+
+- Ran `npm run version:pr`.
+- Ran `node scripts/check-app-version.mjs --compare-ref origin/main --require-pr-minor`.
+- Ran `npm run version:check`.
+- Ran `git diff --check`.
+
 ## 2026-06-24 - Clarify Native Audit Preview And Save Flow
 
 Status: Completed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-log-viewer",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-log-viewer",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "workspaces": [
         "packages/*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-log-viewer",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "description": "Local-first native macOS app and parser for OpenAI Codex session logs.",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- rename the native Audit actions so preview generation and file saving are distinct
- disable Open Worklog until an existing or newly saved worklog is available
- add native smoke coverage for preview-not-writing and save-writing the audit worklog

## Verification
- wt bootstrap
- npm run build:mac
- npm run package:mac
- npm run smoke:mac-ui (passed on clean rerun after cleaning a leaked smoke app process)
- npm run smoke:mac-package
- npm run check:mac-accessibility
- npm run check:mac-accessibility (publish-time rerun)