### PR TITLE
Fix workflow-only PR version check on merge refs

### DIFF
--- a/app-version.json
+++ b/app-version.json
@@ -1,5 +1,5 @@
 {
   "major": 0,
-  "minor": 8,
+  "minor": 9,
   "patch": 0
 }

--- a/apps/macos/Sources/CodexLogViewerMac/AppVersion.swift
+++ b/apps/macos/Sources/CodexLogViewerMac/AppVersion.swift
@@ -3,9 +3,9 @@
 
 enum AppVersion {
   static let major = 0
-  static let minor = 8
+  static let minor = 9
   static let patch = 0
-  static let marketingVersion = "0.8.0"
-  static let bundleVersion = "0.8.0"
-  static let displayVersion = "0.8.0"
+  static let marketingVersion = "0.9.0"
+  static let bundleVersion = "0.9.0"
+  static let displayVersion = "0.9.0"
 }

--- a/docs/ai-worklog.md
+++ b/docs/ai-worklog.md
@@ -34,6 +34,42 @@ No raw Codex logs, private session content, secrets, or unsanitized local paths 
 - Ran `node scripts/check-app-version.mjs --compare-ref origin/main --require-pr-minor`.
 - Ran `git diff --check`.
 
+## 2026-06-30 - Fix Workflow-Only PR Detection On Merge Refs
+
+Status: Completed
+Related commit/PR: TBD
+
+### User Messages
+
+> Automation: Daily GitHub Attention Check
+>
+> Use the connected GitHub account for Cris Pierry (`crispierry`) to check GitHub repositories, pull requests, failed pushes/checks, and related GitHub issues for items that need Cris's attention.
+
+### Interpreted Intent
+
+The automation needed current GitHub blockers triaged, safe fixes applied directly, and only remaining owner actions escalated.
+
+### Response / Work Done
+
+- Identified `crispierry/codex-log-viewer#24` as the only open PR that still needed owner attention.
+- Confirmed the failing `verify` job was caused by the app-version gate reading changed files from GitHub's synthetic PR merge commit instead of the PR head.
+- Updated the version-check script so workflow-only pull requests are detected against the PR head when CI runs on a merge ref.
+- Re-ran the repository PR version workflow after `origin/main` advanced so the fix branch moved from `0.8.0` to `0.9.0` and satisfied the repository policy.
+- Prepared a follow-up fix branch so Cris can merge the policy repair before revisiting the Dependabot PR.
+
+### Privacy Notes
+
+No raw Codex logs, private prompts, session contents, screenshots, recordings, export payloads, credentials, secrets, or unsanitized local session paths were added.
+
+### Verification
+
+- Ran `wt bootstrap`.
+- Ran `git diff --name-only origin/main...pr-24`.
+- Ran `git diff --name-only origin/main...pr-24-merge`.
+- Ran `node scripts/check-app-version.mjs --compare-ref origin/main --require-pr-minor` from the synthetic merge-ref checkout after the patch.
+- Ran `npm run version:pr`.
+- Ran `node scripts/check-app-version.mjs --compare-ref origin/main --require-pr-minor`.
+
 ## 2026-06-27 - Exempt Workflow-Only PRs From App Version Gate
 
 Status: Completed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-log-viewer",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-log-viewer",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "workspaces": [
         "packages/*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-log-viewer",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "description": "Local-first native macOS app and parser for OpenAI Codex session logs.",
   "license": "MIT",

--- a/scripts/check-app-version.mjs
+++ b/scripts/check-app-version.mjs
@@ -86,7 +86,7 @@ function readVersionFromGit(ref) {
 }
 
 function onlyWorkflowFilesChanged(ref) {
-  const raw = execFileSync("git", ["diff", "--name-only", `${ref}...HEAD`], {
+  const raw = execFileSync("git", ["diff", "--name-only", `${ref}...${resolveDiffHead(ref)}`], {
     cwd: repoRoot,
     encoding: "utf8"
   });
@@ -99,6 +99,33 @@ function onlyWorkflowFilesChanged(ref) {
     changedFiles.length > 0 &&
     changedFiles.every((file) => file.startsWith(".github/workflows/"))
   );
+}
+
+function resolveDiffHead(ref) {
+  const parents = execFileSync("git", ["rev-list", "--parents", "-n", "1", "HEAD"], {
+    cwd: repoRoot,
+    encoding: "utf8"
+  })
+    .trim()
+    .split(/\s+/);
+
+  if (parents.length === 3 && isAncestor(ref, parents[1])) {
+    return parents[2];
+  }
+
+  return "HEAD";
+}
+
+function isAncestor(ancestorRef, descendantRef) {
+  try {
+    execFileSync("git", ["merge-base", "--is-ancestor", ancestorRef, descendantRef], {
+      cwd: repoRoot,
+      stdio: "ignore"
+    });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function parseVersion(raw, label) {


### PR DESCRIPTION
## Summary
- detect workflow-only changes from the PR head when GitHub Actions checks out a synthetic merge commit
- keep the app-version gate active for normal code changes
- record the automation fix in the AI worklog

## Verification
- wt bootstrap
- git diff --name-only origin/main...pr-24
- git diff --name-only origin/main...pr-24-merge
- node scripts/check-app-version.mjs --compare-ref origin/main --require-pr-minor (from the patched pr-24 merge-ref worktree)
- node scripts/check-app-version.mjs
- git diff --check

## Follow-up
- after this merges, refresh or re-run #24 so the Dependabot workflow update can pass verify